### PR TITLE
Support reserved in enum

### DIFF
--- a/parser/enum.go
+++ b/parser/enum.go
@@ -177,6 +177,13 @@ func (p *Parser) parseEnumBody() (
 			}
 			option.Comments = comments
 			stmt = option
+		case scanner.TRESERVED:
+			reserved, err := p.ParseReserved()
+			if err != nil {
+				return nil, nil, scanner.Position{}, err
+			}
+			reserved.Comments = comments
+			stmt = reserved
 		default:
 			enumField, enumFieldErr := p.parseEnumField()
 			if enumFieldErr == nil {


### PR DESCRIPTION
Change-Id: I0362c20ea26518b152c91e82584a889ca192e350

enum also support reserved, refer to this link:
https://developers.google.com/protocol-buffers/docs/proto3#enum_reserved