### PR TITLE
allow ident start with underscore

### DIFF
--- a/internal/lexer/scanner/scanner.go
+++ b/internal/lexer/scanner/scanner.go
@@ -120,7 +120,7 @@ func (s *Scanner) scan() (Token, string, Position, error) {
 		return s.scan()
 	case s.isEOF():
 		return TEOF, "", startPos, nil
-	case isLetter(ch):
+	case isLetter(ch), ch == '_':
 		ident := s.scanIdent()
 		if s.Mode&ScanBoolLit != 0 && isBoolLit(ident) {
 			return TBOOLLIT, ident, startPos, nil

--- a/internal/lexer/scanner/scanner_test.go
+++ b/internal/lexer/scanner/scanner_test.go
@@ -30,7 +30,7 @@ func TestScanner_Scan(t *testing.T) {
 		},
 		{
 			name:  "scan idents",
-			input: "service s1928 s_a 1ac-",
+			input: "service s1928 s_a 1ac- _s_a",
 			wants: []want{
 				{
 					token: scanner.TIDENT,
@@ -84,6 +84,15 @@ func TestScanner_Scan(t *testing.T) {
 						Offset: 21,
 						Line:   1,
 						Column: 22,
+					},
+				},
+				{
+					token: scanner.TIDENT,
+					text:  "_s_a",
+					pos: scanner.Position{
+						Offset: 23,
+						Line:   1,
+						Column: 24,
 					},
 				},
 			},


### PR DESCRIPTION
Change-Id: I4756755c0f684e51a5dffa36a458276ee4e60611

I know it's insane, but other parser allow ident start with underscore...

There is even a test case for this:
https://github.com/golang/protobuf/blob/master/protoc-gen-go/generator/name_test.go#L51