### PR TITLE
feat: Accept a block followed by a semicolon

### DIFF
--- a/internal/lexer/lexer.go
+++ b/internal/lexer/lexer.go
@@ -160,3 +160,12 @@ func (lex *Lexer) UnNextTo(lastScan []rune) {
 	lex.scanner.UnScan()
 	lex.Token = scanner.TILLEGAL
 }
+
+// ConsumeToken consumes a given token if it exists. Otherwise, it consumes no token.
+func (lex *Lexer) ConsumeToken(t scanner.Token) {
+	lex.Next()
+	if lex.Token == t {
+		return
+	}
+	lex.UnNext()
+}

--- a/parser/enum.go
+++ b/parser/enum.go
@@ -123,6 +123,11 @@ func (p *Parser) ParseEnum() (*Enum, error) {
 		return nil, err
 	}
 
+	if p.permissive {
+		// accept a block followed by semicolon. See https://github.com/yoheimuta/go-protoparser/issues/30.
+		p.lex.ConsumeToken(scanner.TSEMICOLON)
+	}
+
 	return &Enum{
 		EnumName:                     enumName,
 		EnumBody:                     enumBody,

--- a/parser/enum_test.go
+++ b/parser/enum_test.go
@@ -16,6 +16,7 @@ func TestParser_ParseEnum(t *testing.T) {
 		name                       string
 		input                      string
 		inputBodyIncludingComments bool
+		permissive                 bool
 		wantEnum                   *parser.Enum
 		wantErr                    bool
 	}{
@@ -463,6 +464,28 @@ func TestParser_ParseEnum(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "parsing a block followed by semicolon",
+			input: `enum EnumAllowingAlias {
+};
+`,
+			permissive: true,
+			wantEnum: &parser.Enum{
+				EnumName: "EnumAllowingAlias",
+				Meta: meta.Meta{
+					Pos: meta.Position{
+						Offset: 0,
+						Line:   1,
+						Column: 1,
+					},
+					LastPos: meta.Position{
+						Offset: 25,
+						Line:   2,
+						Column: 1,
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -471,6 +494,7 @@ func TestParser_ParseEnum(t *testing.T) {
 			p := parser.NewParser(
 				lexer.NewLexer(strings.NewReader(test.input)),
 				parser.WithBodyIncludingComments(test.inputBodyIncludingComments),
+				parser.WithPermissive(test.permissive),
 			)
 			got, err := p.ParseEnum()
 			switch {

--- a/parser/extend.go
+++ b/parser/extend.go
@@ -83,6 +83,11 @@ func (p *Parser) ParseExtend() (*Extend, error) {
 		return nil, err
 	}
 
+	if p.permissive {
+		// accept a block followed by semicolon. See https://github.com/yoheimuta/go-protoparser/issues/30.
+		p.lex.ConsumeToken(scanner.TSEMICOLON)
+	}
+
 	return &Extend{
 		MessageType:                  messageType,
 		ExtendBody:                   extendBody,

--- a/parser/extend_test.go
+++ b/parser/extend_test.go
@@ -17,6 +17,7 @@ func TestParser_ParseExtend(t *testing.T) {
 		name                       string
 		input                      string
 		inputBodyIncludingComments bool
+		permissive                 bool
 		wantExtend                 *parser.Extend
 		wantErr                    bool
 	}{
@@ -110,6 +111,29 @@ extend google.protobuf.MethodOptions {
 				},
 			},
 		},
+		{
+			name: "parsing a block followed by semicolon",
+			input: `
+extend Foo {
+};
+`,
+			permissive: true,
+			wantExtend: &parser.Extend{
+				MessageType: "Foo",
+				Meta: meta.Meta{
+					Pos: meta.Position{
+						Offset: 1,
+						Line:   2,
+						Column: 1,
+					},
+					LastPos: meta.Position{
+						Offset: 14,
+						Line:   3,
+						Column: 1,
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -118,6 +142,7 @@ extend google.protobuf.MethodOptions {
 			p := parser.NewParser(
 				lexer.NewLexer(strings.NewReader(test.input)),
 				parser.WithBodyIncludingComments(test.inputBodyIncludingComments),
+				parser.WithPermissive(test.permissive),
 			)
 			got, err := p.ParseExtend()
 			switch {

--- a/parser/groupField.go
+++ b/parser/groupField.go
@@ -104,6 +104,11 @@ func (p *Parser) ParseGroupField() (*GroupField, error) {
 		return nil, err
 	}
 
+	if p.permissive {
+		// accept a block followed by semicolon. See https://github.com/yoheimuta/go-protoparser/issues/30.
+		p.lex.ConsumeToken(scanner.TSEMICOLON)
+	}
+
 	return &GroupField{
 		IsRepeated:  isRepeated,
 		IsRequired:  isRequired,

--- a/parser/groupField_test.go
+++ b/parser/groupField_test.go
@@ -103,6 +103,30 @@ repeated group Result = 1 {
 				},
 			},
 		},
+		{
+			name: "parsing a block followed by semicolon",
+			input: `
+group Result = 1 {
+};
+`,
+			permissive: true,
+			wantGroupField: &parser.GroupField{
+				GroupName:   "Result",
+				FieldNumber: "1",
+				Meta: meta.Meta{
+					Pos: meta.Position{
+						Offset: 1,
+						Line:   2,
+						Column: 1,
+					},
+					LastPos: meta.Position{
+						Offset: 20,
+						Line:   3,
+						Column: 1,
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/parser/message.go
+++ b/parser/message.go
@@ -84,6 +84,11 @@ func (p *Parser) ParseMessage() (*Message, error) {
 		return nil, err
 	}
 
+	if p.permissive {
+		// accept a block followed by semicolon. See https://github.com/yoheimuta/go-protoparser/issues/30.
+		p.lex.ConsumeToken(scanner.TSEMICOLON)
+	}
+
 	return &Message{
 		MessageName:                  messageName,
 		MessageBody:                  messageBody,

--- a/parser/oneof.go
+++ b/parser/oneof.go
@@ -125,6 +125,11 @@ func (p *Parser) ParseOneof() (*Oneof, error) {
 		}
 	}
 
+	if p.permissive {
+		// accept a block followed by semicolon. See https://github.com/yoheimuta/go-protoparser/issues/30.
+		p.lex.ConsumeToken(scanner.TSEMICOLON)
+	}
+
 	return &Oneof{
 		OneofFields:                  oneofFields,
 		OneofName:                    oneofName,

--- a/parser/service.go
+++ b/parser/service.go
@@ -120,6 +120,11 @@ func (p *Parser) ParseService() (*Service, error) {
 		return nil, err
 	}
 
+	if p.permissive {
+		// accept a block followed by semicolon. See https://github.com/yoheimuta/go-protoparser/issues/30.
+		p.lex.ConsumeToken(scanner.TSEMICOLON)
+	}
+
 	return &Service{
 		ServiceName:                  serviceName,
 		ServiceBody:                  serviceBody,

--- a/parser/service_test.go
+++ b/parser/service_test.go
@@ -16,6 +16,7 @@ func TestParser_ParseService(t *testing.T) {
 		name                       string
 		input                      string
 		inputBodyIncludingComments bool
+		permissive                 bool
 		wantService                *parser.Service
 		wantErr                    bool
 	}{
@@ -591,6 +592,28 @@ service SearchService {
 				},
 			},
 		},
+		{
+			name: "parsing a block followed by semicolon",
+			input: `
+service SearchService {};
+`,
+			permissive: true,
+			wantService: &parser.Service{
+				ServiceName: "SearchService",
+				Meta: meta.Meta{
+					Pos: meta.Position{
+						Offset: 1,
+						Line:   2,
+						Column: 1,
+					},
+					LastPos: meta.Position{
+						Offset: 24,
+						Line:   2,
+						Column: 24,
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -599,6 +622,7 @@ service SearchService {
 			p := parser.NewParser(
 				lexer.NewLexer(strings.NewReader(test.input)),
 				parser.WithBodyIncludingComments(test.inputBodyIncludingComments),
+				parser.WithPermissive(test.permissive),
 			)
 			got, err := p.ParseService()
 			switch {


### PR DESCRIPTION
ref. [Accept block followed by semicolon · Issue #30 · yoheimuta/go-protoparser](https://github.com/yoheimuta/go-protoparser/issues/30)