### PR TITLE
fix: Allow a block followed by semicolon for RPC

### DIFF
--- a/_testdata/simple.proto
+++ b/_testdata/simple.proto
@@ -19,3 +19,6 @@ message outer {
     EnumAllowingAlias enum_field =3;
     map<int32, string> my_map = 4;
 }
+service HelloService {
+  rpc SayHello (HelloRequest) returns (HelloResponse) {};
+}

--- a/parser/service.go
+++ b/parser/service.go
@@ -237,6 +237,10 @@ func (p *Parser) parseRPC() (*RPC, error) {
 		if err != nil {
 			return nil, err
 		}
+		if p.permissive {
+			// accept a block followed by semicolon. See https://github.com/yoheimuta/go-protoparser/issues/30.
+			p.lex.ConsumeToken(scanner.TSEMICOLON)
+		}
 	case scanner.TSEMICOLON:
 		break
 	default:

--- a/parser/service_test.go
+++ b/parser/service_test.go
@@ -595,11 +595,50 @@ service SearchService {
 		{
 			name: "parsing a block followed by semicolon",
 			input: `
-service SearchService {};
+service SearchService {
+  rpc Search (SearchRequest) returns (SearchResponse) {};
+};
 `,
 			permissive: true,
 			wantService: &parser.Service{
 				ServiceName: "SearchService",
+				ServiceBody: []parser.Visitee{
+					&parser.RPC{
+						RPCName: "Search",
+						RPCRequest: &parser.RPCRequest{
+							MessageType: "SearchRequest",
+							Meta: meta.Meta{
+								Pos: meta.Position{
+									Offset: 38,
+									Line:   3,
+									Column: 14,
+								},
+							},
+						},
+						RPCResponse: &parser.RPCResponse{
+							MessageType: "SearchResponse",
+							Meta: meta.Meta{
+								Pos: meta.Position{
+									Offset: 62,
+									Line:   3,
+									Column: 38,
+								},
+							},
+						},
+						Meta: meta.Meta{
+							Pos: meta.Position{
+								Offset: 27,
+								Line:   3,
+								Column: 3,
+							},
+							LastPos: meta.Position{
+								Offset: 81,
+								Line:   3,
+								Column: 57,
+							},
+						},
+					},
+				},
 				Meta: meta.Meta{
 					Pos: meta.Position{
 						Offset: 1,
@@ -607,9 +646,9 @@ service SearchService {};
 						Column: 1,
 					},
 					LastPos: meta.Position{
-						Offset: 24,
-						Line:   2,
-						Column: 24,
+						Offset: 83,
+						Line:   4,
+						Column: 1,
 					},
 				},
 			},


### PR DESCRIPTION
ref. [Accept block followed by semicolon · Issue #30 · yoheimuta/go-protoparser](https://github.com/yoheimuta/go-protoparser/issues/30)