### PR TITLE
feat: Support multiline string literals

### DIFF
--- a/_testdata/simple.proto
+++ b/_testdata/simple.proto
@@ -8,7 +8,9 @@ enum EnumAllowingAlias {
     option allow_alias = true;
     UNKNOWN = 0;
     STARTED = 1;
-    RUNNING = 2 [(custom_option) = "hello world"];
+    RUNNING = 2 [(custom_option) = "this is a "
+                                   "string on two lines"
+                ];
 }
 message outer {
     option (my_option).a = true;

--- a/parser/enum.go
+++ b/parser/enum.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/yoheimuta/go-protoparser/internal/lexer/scanner"
 	"github.com/yoheimuta/go-protoparser/parser/meta"
@@ -313,8 +314,47 @@ func (p *Parser) parseEnumValueOption() (*EnumValueOption, error) {
 		return nil, err
 	}
 
+	if p.permissive {
+		// accept a multiple string literals. See https://github.com/yoheimuta/go-protoparser/issues/35.
+		for {
+			next := p.lex.Peek()
+			if next == scanner.TCOMMA || next == scanner.TRIGHTSQUARE {
+				break
+			}
+
+			lit, _, err := p.lex.ReadConstant()
+			if err != nil {
+				return nil, err
+			}
+			constant = p.concatLiteral(constant, lit)
+		}
+	}
+
 	return &EnumValueOption{
 		OptionName: optionName,
 		Constant:   constant,
 	}, nil
+}
+
+func (p *Parser) concatLiteral(base, next string) string {
+	unQuoteNext, _, err := p.unQuote(next)
+	if err != nil {
+		return base + next
+	}
+
+	unQuoteBase, quote, err := p.unQuote(base)
+	if err != nil {
+		return base + next
+	}
+
+	return string(quote) + unQuoteBase + unQuoteNext + string(quote)
+}
+
+func (p *Parser) unQuote(lit string) (string, rune, error) {
+	for _, c := range []rune{'\'', '"'} {
+		if strings.HasPrefix(lit, string(c)) && strings.HasSuffix(lit, string(c)) {
+			return lit[1 : len(lit)-1], c, nil
+		}
+	}
+	return lit, 0, p.unexpected("quote")
 }

--- a/parser/enum_test.go
+++ b/parser/enum_test.go
@@ -508,6 +508,50 @@ func TestParser_ParseEnum(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "parsing an enum with multiple string literals. See #35",
+			input: `enum EnumAllowingAlias {
+  UNKNOWN = 0 [(custom_option) = "this is a "
+                                 "string on two lines"
+              ];
+}
+`,
+			permissive: true,
+			wantEnum: &parser.Enum{
+				EnumName: "EnumAllowingAlias",
+				EnumBody: []parser.Visitee{
+					&parser.EnumField{
+						Ident:  "UNKNOWN",
+						Number: "0",
+						EnumValueOptions: []*parser.EnumValueOption{
+							{
+								OptionName: "(custom_option)",
+								Constant:   `"this is a string on two lines"`,
+							},
+						},
+						Meta: meta.Meta{
+							Pos: meta.Position{
+								Offset: 27,
+								Line:   2,
+								Column: 3,
+							},
+						},
+					},
+				},
+				Meta: meta.Meta{
+					Pos: meta.Position{
+						Offset: 0,
+						Line:   1,
+						Column: 1,
+					},
+					LastPos: meta.Position{
+						Offset: 143,
+						Line:   5,
+						Column: 1,
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
ref. [Multiline string literals error · Issue #35 · yoheimuta/go-protoparser](https://github.com/yoheimuta/go-protoparser/issues/35)