### PR TITLE
Allow multiline string literal constants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ atlassian-ide-plugin.xml
 # Cursive Clojure plugin
 .idea/replstate.xml
 
+.config/
+tags/

--- a/_testdata/simple.proto
+++ b/_testdata/simple.proto
@@ -13,11 +13,13 @@ enum EnumAllowingAlias {
                 ];
 }
 message outer {
-    option (my_option).a = true;
+    option (my_option).a = "this is a string";
     message inner {   // Level 2
       int64 ival = 1;
     }
-    repeated inner inner_message = 2;
+    repeated inner inner_message = 2[(custom_option) = "this is a "
+                                   "string on two lines"
+                ];
     EnumAllowingAlias enum_field =3;
     map<int32, string> my_map = 4;
 }

--- a/_testdata/simple.proto
+++ b/_testdata/simple.proto
@@ -13,13 +13,11 @@ enum EnumAllowingAlias {
                 ];
 }
 message outer {
-    option (my_option).a = "this is a string";
+    option (my_option).a = true;
     message inner {   // Level 2
       int64 ival = 1;
     }
-    repeated inner inner_message = 2[(custom_option) = "this is a "
-                                   "string on two lines"
-                ];
+    repeated inner inner_message = 2;
     EnumAllowingAlias enum_field =3;
     map<int32, string> my_map = 4;
 }

--- a/internal/lexer/constant.go
+++ b/internal/lexer/constant.go
@@ -1,10 +1,14 @@
 package lexer
 
-import "github.com/yoheimuta/go-protoparser/internal/lexer/scanner"
+import (
+	"strings"
 
-// ReadConstant reads a constant.
+	"github.com/yoheimuta/go-protoparser/internal/lexer/scanner"
+)
+
+// ReadConstant reads a constant. If permissive is true, accepts multiline string literals.
 // constant = fullIdent | ( [ "-" | "+" ] intLit ) | ( [ "-" | "+" ] floatLit ) | strLit | boolLit
-func (lex *Lexer) ReadConstant() (string, scanner.Position, error) {
+func (lex *Lexer) ReadConstant(permissive bool) (string, scanner.Position, error) {
 	lex.NextLit()
 
 	startPos := lex.Pos
@@ -12,7 +16,19 @@ func (lex *Lexer) ReadConstant() (string, scanner.Position, error) {
 
 	switch {
 	case lex.Token == scanner.TSTRLIT:
-		return cons, startPos, nil
+		if !permissive {
+			return cons, startPos, nil
+		}
+		var b strings.Builder
+		b.WriteString("\"")
+		for lex.Token == scanner.TSTRLIT {
+			strippedString := strings.Trim(lex.Text, "\"")
+			b.WriteString(strippedString)
+			lex.NextLit()
+		}
+		lex.UnNext()
+		b.WriteString("\"")
+		return b.String(), startPos, nil
 	case lex.Token == scanner.TBOOLLIT:
 		return cons, startPos, nil
 	case lex.Token == scanner.TIDENT:

--- a/internal/lexer/constant.go
+++ b/internal/lexer/constant.go
@@ -16,19 +16,10 @@ func (lex *Lexer) ReadConstant(permissive bool) (string, scanner.Position, error
 
 	switch {
 	case lex.Token == scanner.TSTRLIT:
-		if !permissive {
-			return cons, startPos, nil
+		if permissive {
+			return lex.mergeMultilineStrLit(), startPos, nil
 		}
-		var b strings.Builder
-		b.WriteString("\"")
-		for lex.Token == scanner.TSTRLIT {
-			strippedString := strings.Trim(lex.Text, "\"")
-			b.WriteString(strippedString)
-			lex.NextLit()
-		}
-		lex.UnNext()
-		b.WriteString("\"")
-		return b.String(), startPos, nil
+		return cons, startPos, nil
 	case lex.Token == scanner.TBOOLLIT:
 		return cons, startPos, nil
 	case lex.Token == scanner.TIDENT:
@@ -53,4 +44,22 @@ func (lex *Lexer) ReadConstant(permissive bool) (string, scanner.Position, error
 	default:
 		return "", scanner.Position{}, lex.unexpected(lex.Text, "constant")
 	}
+}
+
+// Merges a multiline string literal into a single string.
+func (lex *Lexer) mergeMultilineStrLit() string {
+	q := "'"
+	if strings.HasPrefix(lex.Text, "\"") {
+		q = "\""
+	}
+	var b strings.Builder
+	b.WriteString(q)
+	for lex.Token == scanner.TSTRLIT {
+		strippedString := strings.Trim(lex.Text, q)
+		b.WriteString(strippedString)
+		lex.NextLit()
+	}
+	lex.UnNext()
+	b.WriteString(q)
+	return b.String()
 }

--- a/internal/lexer/constant_test.go
+++ b/internal/lexer/constant_test.go
@@ -65,8 +65,8 @@ func TestLexer2_ReadConstant(t *testing.T) {
 		},
 		{
 			name:      "multiline strLit",
-			input:     "\"line1 \"\n\"line2\"",
-			wantText:  `"line1 line2"`,
+			input:     "\"line1 \"\n\"line2 \" \n\"line 3\" ",
+			wantText:  `"line1 line2 line3"`,
 			wantIsEOF: true,
 		},
 		{

--- a/internal/lexer/constant_test.go
+++ b/internal/lexer/constant_test.go
@@ -64,9 +64,15 @@ func TestLexer2_ReadConstant(t *testing.T) {
 			wantIsEOF: true,
 		},
 		{
-			name:      "multiline strLit",
+			name:      "multiline strLit with double quotes",
 			input:     "\"line1 \"\n\"line2 \" \n\"line3\" ",
 			wantText:  `"line1 line2 line3"`,
+			wantIsEOF: true,
+		},
+		{
+			name:      "multiline strLit with single quotes",
+			input:     "'line1 '\n'line2 ' \n'line3' ",
+			wantText:  `'line1 line2 line3'`,
 			wantIsEOF: true,
 		},
 		{

--- a/internal/lexer/constant_test.go
+++ b/internal/lexer/constant_test.go
@@ -58,9 +58,15 @@ func TestLexer2_ReadConstant(t *testing.T) {
 			wantIsEOF: true,
 		},
 		{
-			name:      "strLit",
+			name:      "single line strLit",
 			input:     `"あいうえお''"`,
 			wantText:  `"あいうえお''"`,
+			wantIsEOF: true,
+		},
+		{
+			name:      "multiline strLit",
+			input:     "\"line1 \"\n\"line2\"",
+			wantText:  `"line1 line2"`,
 			wantIsEOF: true,
 		},
 		{
@@ -89,7 +95,7 @@ func TestLexer2_ReadConstant(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			lex := lexer.NewLexer(strings.NewReader(test.input))
-			got, pos, err := lex.ReadConstant()
+			got, pos, err := lex.ReadConstant(true)
 
 			switch {
 			case test.wantErr:

--- a/internal/lexer/constant_test.go
+++ b/internal/lexer/constant_test.go
@@ -65,7 +65,7 @@ func TestLexer2_ReadConstant(t *testing.T) {
 		},
 		{
 			name:      "multiline strLit",
-			input:     "\"line1 \"\n\"line2 \" \n\"line 3\" ",
+			input:     "\"line1 \"\n\"line2 \" \n\"line3\" ",
 			wantText:  `"line1 line2 line3"`,
 			wantIsEOF: true,
 		},

--- a/parser/enum.go
+++ b/parser/enum.go
@@ -2,7 +2,6 @@ package parser
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/yoheimuta/go-protoparser/internal/lexer/scanner"
 	"github.com/yoheimuta/go-protoparser/parser/meta"
@@ -314,47 +313,8 @@ func (p *Parser) parseEnumValueOption() (*EnumValueOption, error) {
 		return nil, err
 	}
 
-	if p.permissive {
-		// accept a multiple string literals. See https://github.com/yoheimuta/go-protoparser/issues/35.
-		for {
-			next := p.lex.Peek()
-			if next == scanner.TCOMMA || next == scanner.TRIGHTSQUARE {
-				break
-			}
-
-			lit, _, err := p.lex.ReadConstant(p.permissive)
-			if err != nil {
-				return nil, err
-			}
-			constant = p.concatLiteral(constant, lit)
-		}
-	}
-
 	return &EnumValueOption{
 		OptionName: optionName,
 		Constant:   constant,
 	}, nil
-}
-
-func (p *Parser) concatLiteral(base, next string) string {
-	unQuoteNext, _, err := p.unQuote(next)
-	if err != nil {
-		return base + next
-	}
-
-	unQuoteBase, quote, err := p.unQuote(base)
-	if err != nil {
-		return base + next
-	}
-
-	return string(quote) + unQuoteBase + unQuoteNext + string(quote)
-}
-
-func (p *Parser) unQuote(lit string) (string, rune, error) {
-	for _, c := range []rune{'\'', '"'} {
-		if strings.HasPrefix(lit, string(c)) && strings.HasSuffix(lit, string(c)) {
-			return lit[1 : len(lit)-1], c, nil
-		}
-	}
-	return lit, 0, p.unexpected("quote")
 }

--- a/parser/enum.go
+++ b/parser/enum.go
@@ -309,7 +309,7 @@ func (p *Parser) parseEnumValueOption() (*EnumValueOption, error) {
 		return nil, p.unexpected("=")
 	}
 
-	constant, _, err := p.lex.ReadConstant()
+	constant, _, err := p.lex.ReadConstant(p.permissive)
 	if err != nil {
 		return nil, err
 	}
@@ -322,7 +322,7 @@ func (p *Parser) parseEnumValueOption() (*EnumValueOption, error) {
 				break
 			}
 
-			lit, _, err := p.lex.ReadConstant()
+			lit, _, err := p.lex.ReadConstant(p.permissive)
 			if err != nil {
 				return nil, err
 			}

--- a/parser/field.go
+++ b/parser/field.go
@@ -186,7 +186,7 @@ func (p *Parser) parseFieldOption() (*FieldOption, error) {
 			return nil, err
 		}
 	default:
-		constant, _, err = p.lex.ReadConstant()
+		constant, _, err = p.lex.ReadConstant(p.permissive)
 		if err != nil {
 			return nil, err
 		}
@@ -221,7 +221,7 @@ func (p *Parser) parseGoProtoValidatorFieldOptionConstant() (string, error) {
 		}
 		ret += p.lex.Text
 
-		constant, _, err := p.lex.ReadConstant()
+		constant, _, err := p.lex.ReadConstant(p.permissive)
 		if err != nil {
 			return "", err
 		}

--- a/parser/option.go
+++ b/parser/option.go
@@ -71,7 +71,7 @@ func (p *Parser) ParseOption() (*Option, error) {
 			return nil, err
 		}
 	default:
-		constant, _, err = p.lex.ReadConstant()
+		constant, _, err = p.lex.ReadConstant(p.permissive)
 		if err != nil {
 			return nil, err
 		}
@@ -114,7 +114,7 @@ func (p *Parser) parseCloudEndpointsOptionConstant() (string, error) {
 		}
 		ret += p.lex.Text
 
-		constant, _, err := p.lex.ReadConstant()
+		constant, _, err := p.lex.ReadConstant(p.permissive)
 		if err != nil {
 			return "", err
 		}

--- a/parser/option_test.go
+++ b/parser/option_test.go
@@ -124,6 +124,28 @@ option (google.api.http) = {
 				},
 			},
 		},
+		{
+			name: "parses multiline string literal in multi-option annotation",
+			input: `
+option (google.api.http) = {
+    post: "/v1/resources",
+    body: "res"
+		      "ource",
+    rest_method_name: "insert"
+};`,
+			permissive: true,
+			wantOption: &parser.Option{
+				OptionName: "(google.api.http)",
+				Constant:   `{post:"/v1/resources",body:"resource",rest_method_name:"insert"}`,
+				Meta: meta.Meta{
+					Pos: meta.Position{
+						Offset: 1,
+						Line:   2,
+						Column: 1,
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Motivated by #35.

Modifies constants lexer to combine series of multiline string literals into a single string literal constant. Removes the code that previously did this specifically for enums, as this now applies to all object types.