### PR TITLE
Add ParseError type.

### DIFF
--- a/errors/parse.go
+++ b/errors/parse.go
@@ -1,0 +1,38 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+package errors
+
+import (
+	"fmt"
+)
+
+// ParseError is the error returned during parsing.
+type ParseError struct {
+	Found      string
+	Expected   string
+	occurredIn string
+	occurredAt int
+}
+
+func (pe ParseError) String() string {
+	out := fmt.Sprintf("found %q but expected [%s]", pe.Found, pe.Expected)
+
+	if pe.occurredIn != "" && pe.occurredAt != 0 {
+		out += fmt.Sprintf(" at %s:%d", pe.occurredIn, pe.occurredAt)
+	}
+
+	return out
+}
+
+func (pe ParseError) Error() string {
+	return pe.String()
+}
+
+func NewParseError(found string, expected string, occuredIn string, occuredAt int) ParseError {
+	return ParseError{
+		Found:      found,
+		Expected:   expected,
+		occurredIn: occuredIn,
+		occurredAt: occuredAt,
+	}
+}

--- a/internal/lexer/error.go
+++ b/internal/lexer/error.go
@@ -7,10 +7,17 @@ import (
 )
 
 func (lex *Lexer) unexpected(found, expected string) error {
-	file := ""
-	line := 0
-	if lex.debug {
-		_, file, line, _ = runtime.Caller(1)
+	pe := issues.ParseError{
+		Filename: lex.Pos.Filename,
+		Line:     lex.Pos.Line,
+		Column:   lex.Pos.Column,
+		Found:    found,
+		Expected: expected,
 	}
-	return issues.NewParseError(found, expected, file, line)
+	if lex.debug {
+		_, file, line, _ := runtime.Caller(1)
+		pe.SetOccured(file, line)
+	}
+
+	return pe
 }

--- a/internal/lexer/error.go
+++ b/internal/lexer/error.go
@@ -3,7 +3,7 @@ package lexer
 import (
 	"runtime"
 
-	"github.com/yoheimuta/go-protoparser/errors"
+	"github.com/yoheimuta/go-protoparser/issues"
 )
 
 func (lex *Lexer) unexpected(found, expected string) error {
@@ -12,5 +12,5 @@ func (lex *Lexer) unexpected(found, expected string) error {
 	if lex.debug {
 		_, file, line, _ = runtime.Caller(1)
 	}
-	return errors.NewParseError(found, expected, file, line)
+	return issues.NewParseError(found, expected, file, line)
 }

--- a/internal/lexer/error.go
+++ b/internal/lexer/error.go
@@ -1,15 +1,16 @@
 package lexer
 
 import (
-	"fmt"
 	"runtime"
+
+	"github.com/yoheimuta/go-protoparser/errors"
 )
 
 func (lex *Lexer) unexpected(found, expected string) error {
-	debug := ""
+	file := ""
+	line := 0
 	if lex.debug {
-		_, file, line, _ := runtime.Caller(1)
-		debug = fmt.Sprintf(" at %s:%d", file, line)
+		_, file, line, _ = runtime.Caller(1)
 	}
-	return fmt.Errorf("found %q but expected [%s]%s", found, expected, debug)
+	return errors.NewParseError(found, expected, file, line)
 }

--- a/internal/lexer/lexer.go
+++ b/internal/lexer/lexer.go
@@ -1,6 +1,7 @@
 package lexer
 
 import (
+	"fmt"
 	"io"
 	"log"
 	"path/filepath"
@@ -31,6 +32,10 @@ type Lexer struct {
 	scannerOpts []scanner.Option
 	scanErr     error
 	debug       bool
+}
+
+func (lex *Lexer) String() string {
+	return fmt.Sprintf("%q(Token=%v, Pos=%s)", lex.Text, lex.Token, lex.Pos)
 }
 
 // Option is an option for lexer.NewLexer.

--- a/internal/lexer/scanner/error.go
+++ b/internal/lexer/scanner/error.go
@@ -1,12 +1,12 @@
 package scanner
 
 import (
-	"fmt"
 	"runtime"
+
+	"github.com/yoheimuta/go-protoparser/errors"
 )
 
-func (s *Scanner) unexpected(found rune, expected string) error {
+func (s *Scanner) unexpected(found rune, expected string) errors.ParseError {
 	_, file, line, _ := runtime.Caller(1)
-	message := fmt.Sprintf(" at %s:%d", file, line)
-	return fmt.Errorf("found %q but expected [%s]%s", found, expected, message)
+	return errors.NewParseError(string(found), expected, file, line)
 }

--- a/internal/lexer/scanner/error.go
+++ b/internal/lexer/scanner/error.go
@@ -3,10 +3,10 @@ package scanner
 import (
 	"runtime"
 
-	"github.com/yoheimuta/go-protoparser/errors"
+	"github.com/yoheimuta/go-protoparser/issues"
 )
 
-func (s *Scanner) unexpected(found rune, expected string) errors.ParseError {
+func (s *Scanner) unexpected(found rune, expected string) issues.ParseError {
 	_, file, line, _ := runtime.Caller(1)
-	return errors.NewParseError(string(found), expected, file, line)
+	return issues.NewParseError(string(found), expected, file, line)
 }

--- a/internal/lexer/scanner/error.go
+++ b/internal/lexer/scanner/error.go
@@ -8,5 +8,13 @@ import (
 
 func (s *Scanner) unexpected(found rune, expected string) issues.ParseError {
 	_, file, line, _ := runtime.Caller(1)
-	return issues.NewParseError(string(found), expected, file, line)
+	pe := issues.ParseError{
+		Filename: s.pos.Filename,
+		Line:     s.pos.Line,
+		Column:   s.pos.Column,
+		Found:    string(found),
+		Expected: expected,
+	}
+	pe.SetOccured(file, line)
+	return pe
 }

--- a/issues/error.go
+++ b/issues/error.go
@@ -8,6 +8,10 @@ import (
 
 // ParseError is the error returned during parsing.
 type ParseError struct {
+	Filename string
+	Line     int
+	Column   int
+
 	Found      string
 	Expected   string
 	occurredIn string
@@ -28,12 +32,8 @@ func (pe ParseError) Error() string {
 	return pe.String()
 }
 
-// NewParseError creates new issues, populating the unexported fields for debug data.
-func NewParseError(found string, expected string, occuredIn string, occuredAt int) ParseError {
-	return ParseError{
-		Found:      found,
-		Expected:   expected,
-		occurredIn: occuredIn,
-		occurredAt: occuredAt,
-	}
+// SetOccurred sets the fields to log where each error was raised.
+func (pe *ParseError) SetOccured(occurerdIn string, occurredAt int) {
+	pe.occurredIn = occurerdIn
+	pe.occurredAt = occurredAt
 }

--- a/issues/error.go
+++ b/issues/error.go
@@ -1,6 +1,6 @@
 // Copyright (c) Improbable Worlds Ltd, All Rights Reserved
 
-package errors
+package issues
 
 import (
 	"fmt"
@@ -28,6 +28,7 @@ func (pe ParseError) Error() string {
 	return pe.String()
 }
 
+// NewParseError creates new issues, populating the unexported fields for debug data.
 func NewParseError(found string, expected string, occuredIn string, occuredAt int) ParseError {
 	return ParseError{
 		Found:      found,

--- a/parser/error.go
+++ b/parser/error.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"runtime"
 
-	"github.com/yoheimuta/go-protoparser/errors"
+	"github.com/yoheimuta/go-protoparser/issues"
 )
 
-func (p *Parser) unexpected(expected string) errors.ParseError {
+func (p *Parser) unexpected(expected string) issues.ParseError {
 	_, file, line, _ := runtime.Caller(1)
 
-	return errors.NewParseError(
+	return issues.NewParseError(
 		p.lex.String(),
 		expected,
 		file,

--- a/parser/error.go
+++ b/parser/error.go
@@ -10,12 +10,15 @@ import (
 func (p *Parser) unexpected(expected string) issues.ParseError {
 	_, file, line, _ := runtime.Caller(1)
 
-	return issues.NewParseError(
-		p.lex.String(),
-		expected,
-		file,
-		line,
-	)
+	pe := issues.ParseError{
+		Filename: p.lex.Pos.Filename,
+		Line:     p.lex.Pos.Line,
+		Column:   p.lex.Pos.Column,
+		Found:    p.lex.String(),
+		Expected: expected,
+	}
+	pe.SetOccured(file, line)
+	return pe
 }
 
 func (p *Parser) unexpectedf(

--- a/parser/error.go
+++ b/parser/error.go
@@ -7,6 +7,7 @@ import (
 	"github.com/yoheimuta/go-protoparser/internal/lexer"
 )
 
+// ParseError is the error returned during parsing.
 type ParseError struct {
 	Lexer *lexer.Lexer
 

--- a/parser/error.go
+++ b/parser/error.go
@@ -3,12 +3,35 @@ package parser
 import (
 	"fmt"
 	"runtime"
+
+	"github.com/yoheimuta/go-protoparser/internal/lexer"
 )
 
-func (p *Parser) unexpected(expected string) error {
+type ParseError struct {
+	Lexer *lexer.Lexer
+
+	Expected  string
+	occuredIn string
+	occuredAt int
+}
+
+func (pe ParseError) String() string {
+	return fmt.Sprintf("found %q(Token=%v, Pos=%s) but expected [%s] at %s:%d", pe.Lexer.Text, pe.Lexer.Token, pe.Lexer.Pos, pe.Expected, pe.occuredIn, pe.occuredAt)
+}
+
+func (pe ParseError) Error() string {
+	return pe.String()
+}
+
+func (p *Parser) unexpected(expected string) ParseError {
 	_, file, line, _ := runtime.Caller(1)
-	msg := fmt.Sprintf(" at %s:%d", file, line)
-	return fmt.Errorf("found %q(Token=%v, Pos=%s) but expected [%s]%s", p.lex.Text, p.lex.Token, p.lex.Pos, expected, msg)
+
+	return ParseError{
+		Lexer:     p.lex,
+		Expected:  expected,
+		occuredIn: file,
+		occuredAt: line,
+	}
 }
 
 func (p *Parser) unexpectedf(

--- a/parser/error.go
+++ b/parser/error.go
@@ -4,35 +4,18 @@ import (
 	"fmt"
 	"runtime"
 
-	"github.com/yoheimuta/go-protoparser/internal/lexer"
+	"github.com/yoheimuta/go-protoparser/errors"
 )
 
-// ParseError is the error returned during parsing.
-type ParseError struct {
-	Lexer *lexer.Lexer
-
-	Expected  string
-	occuredIn string
-	occuredAt int
-}
-
-func (pe ParseError) String() string {
-	return fmt.Sprintf("found %q(Token=%v, Pos=%s) but expected [%s] at %s:%d", pe.Lexer.Text, pe.Lexer.Token, pe.Lexer.Pos, pe.Expected, pe.occuredIn, pe.occuredAt)
-}
-
-func (pe ParseError) Error() string {
-	return pe.String()
-}
-
-func (p *Parser) unexpected(expected string) ParseError {
+func (p *Parser) unexpected(expected string) errors.ParseError {
 	_, file, line, _ := runtime.Caller(1)
 
-	return ParseError{
-		Lexer:     p.lex,
-		Expected:  expected,
-		occuredIn: file,
-		occuredAt: line,
-	}
+	return errors.NewParseError(
+		p.lex.String(),
+		expected,
+		file,
+		line,
+	)
 }
 
 func (p *Parser) unexpectedf(


### PR DESCRIPTION
Added a specific error type to return when reporting parsing errors, such as to be able to inspect them in more detail. No formatting should be affected by this change.

This is required to stop linting from stopping on parse errors in the following FR: github.com/yoheimuta/protolint/issues/101