### PR TITLE
Add gomod file for easier contributions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,26 +1,8 @@
-# User-specific stuff:
-.idea/**/workspace.xml
-.idea/**/tasks.xml
-.idea/dictionaries
-
-# Sensitive or high-churn files:
-.idea/**/dataSources/
-.idea/**/dataSources.ids
-.idea/**/dataSources.xml
-.idea/**/dataSources.local.xml
-.idea/**/sqlDataSources.xml
-.idea/**/dynamic.xml
-.idea/**/uiDesigner.xml
-
-# Gradle:
-.idea/**/gradle.xml
-.idea/**/libraries
+# user-specific .idea files
+.idea
 
 # CMake
 cmake-build-debug/
-
-# Mongo Explorer plugin:
-.idea/**/mongoSettings.xml
 
 ## File-based project format:
 *.iws
@@ -35,9 +17,6 @@ out/
 
 # JIRA plugin
 atlassian-ide-plugin.xml
-
-# Cursive Clojure plugin
-.idea/replstate.xml
 
 .config/
 tags/

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/yoheimuta/go-protoparser
+
+go 1.13


### PR DESCRIPTION
Using internal package paths makes it difficult to contribute without a gomod file, since the importpath does not resolve correctly. This adds the gomod file, to avoid this.

Also, /gitignore the `.idea` folder.