### PR TITLE
Improve flexibility of parsing tool

### DIFF
--- a/parser/field.go
+++ b/parser/field.go
@@ -198,7 +198,7 @@ func (p *Parser) parseFieldOption() (*FieldOption, error) {
 	}, nil
 }
 
-// goProtoValidatorFieldOptionConstant = "{" ident ":" constant { , ident ":" constant } "}"
+// goProtoValidatorFieldOptionConstant = "{" ident ":" constant { "," ident ":" constant } [ "," ] "}"
 func (p *Parser) parseGoProtoValidatorFieldOptionConstant() (string, error) {
 	var ret string
 
@@ -231,6 +231,11 @@ func (p *Parser) parseGoProtoValidatorFieldOptionConstant() (string, error) {
 		switch {
 		case p.lex.Token == scanner.TCOMMA:
 			ret += p.lex.Text
+			if p.lex.Peek() == scanner.TRIGHTCURLY {
+				p.lex.Next()
+				ret += p.lex.Text
+				return ret, nil
+			}
 		case p.lex.Token == scanner.TRIGHTCURLY:
 			ret += p.lex.Text
 			return ret, nil

--- a/parser/field.go
+++ b/parser/field.go
@@ -231,7 +231,7 @@ func (p *Parser) parseGoProtoValidatorFieldOptionConstant() (string, error) {
 		switch {
 		case p.lex.Token == scanner.TCOMMA:
 			ret += p.lex.Text
-			if p.lex.Peek() == scanner.TRIGHTCURLY {
+			if p.lex.Peek() == scanner.TRIGHTCURLY && p.permissive {
 				p.lex.Next()
 				ret += p.lex.Text
 				return ret, nil

--- a/parser/field_test.go
+++ b/parser/field_test.go
@@ -128,6 +128,29 @@ func TestParser_ParseField(t *testing.T) {
 			},
 		},
 		{
+			name:       "parsing fieldOption constant with { and a trailing comma by permissive mode",
+			input:      "int64 display_order = 1 [(validator.field) = {int_gt: 0,}];",
+			permissive: true,
+			wantField: &parser.Field{
+				Type:        "int64",
+				FieldName:   "display_order",
+				FieldNumber: "1",
+				FieldOptions: []*parser.FieldOption{
+					{
+						OptionName: "(validator.field)",
+						Constant:   "{int_gt:0,}",
+					},
+				},
+				Meta: meta.Meta{
+					Pos: meta.Position{
+						Offset: 0,
+						Line:   1,
+						Column: 1,
+					},
+				},
+			},
+		},
+		{
 			name:       "parsing fieldOption constant with { and , by permissive mode. Required by go-proto-validators",
 			input:      `string email = 2 [(validator.field) = {length_gt: 0, length_lt: 1025},(validator.field) = {regex: "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"}];`,
 			permissive: true,

--- a/parser/option.go
+++ b/parser/option.go
@@ -75,7 +75,7 @@ func (p *Parser) ParseOption() (*Option, error) {
 	}, nil
 }
 
-// cloudEndpointsOptionConstant = "{" ident ":" constant { ( [","] ident ":" constant | cloudEndpointsOptionConstant ) } [","] "}"
+// cloudEndpointsOptionConstant = "{" ident ":" constant { ( ["," | ";" ] ident ":" constant | cloudEndpointsOptionConstant ) } ["," | ";"] "}"
 //
 // See https://cloud.google.com/endpoints/docs/grpc-service-config/reference/rpc/google.api
 func (p *Parser) parseCloudEndpointsOptionConstant() (string, error) {
@@ -122,7 +122,7 @@ func (p *Parser) parseCloudEndpointsOptionConstant() (string, error) {
 		}
 
 		switch {
-		case p.lex.Token == scanner.TCOMMA:
+		case p.lex.Token == scanner.TCOMMA, p.lex.Token == scanner.TSEMICOLON:
 			ret += p.lex.Text
 			if p.lex.Peek() == scanner.TRIGHTCURLY {
 				p.lex.Next()

--- a/parser/option.go
+++ b/parser/option.go
@@ -75,7 +75,7 @@ func (p *Parser) ParseOption() (*Option, error) {
 	}, nil
 }
 
-// cloudEndpointsOptionConstant = "{" ident ":" constant { ( [","] ident ":" constant | cloudEndpointsOptionConstant ) } "}"
+// cloudEndpointsOptionConstant = "{" ident ":" constant { ( [","] ident ":" constant | cloudEndpointsOptionConstant ) } [","] "}"
 //
 // See https://cloud.google.com/endpoints/docs/grpc-service-config/reference/rpc/google.api
 func (p *Parser) parseCloudEndpointsOptionConstant() (string, error) {
@@ -124,6 +124,11 @@ func (p *Parser) parseCloudEndpointsOptionConstant() (string, error) {
 		switch {
 		case p.lex.Token == scanner.TCOMMA:
 			ret += p.lex.Text
+			if p.lex.Peek() == scanner.TRIGHTCURLY {
+				p.lex.Next()
+				ret += p.lex.Text
+				return ret, nil
+			}
 		case p.lex.Token == scanner.TRIGHTCURLY:
 			ret += p.lex.Text
 			return ret, nil

--- a/parser/option.go
+++ b/parser/option.go
@@ -94,6 +94,7 @@ func (p *Parser) parseCloudEndpointsOptionConstant() (string, error) {
 		}
 		ret += p.lex.Text
 
+		needSemi := false
 		p.lex.Next()
 		switch p.lex.Token {
 		case scanner.TLEFTCURLY:
@@ -101,6 +102,9 @@ func (p *Parser) parseCloudEndpointsOptionConstant() (string, error) {
 			fallthrough
 		case scanner.TCOLON:
 			ret += p.lex.Text
+			if p.lex.Peek() == scanner.TLEFTCURLY {
+				needSemi = true
+			}
 		default:
 			return "", p.unexpected("{ or :")
 		}
@@ -112,6 +116,11 @@ func (p *Parser) parseCloudEndpointsOptionConstant() (string, error) {
 		ret += constant
 
 		p.lex.Next()
+		if p.lex.Token == scanner.TSEMICOLON && needSemi {
+			ret += p.lex.Text
+			p.lex.Next()
+		}
+
 		switch {
 		case p.lex.Token == scanner.TCOMMA:
 			ret += p.lex.Text
@@ -179,6 +188,7 @@ func (p *Parser) parseOptionConstant() (constant string, err error) {
 		if err != nil {
 			return "", err
 		}
+
 	default:
 		constant, _, err = p.lex.ReadConstant(p.permissive)
 		if err != nil {

--- a/parser/option_test.go
+++ b/parser/option_test.go
@@ -146,6 +146,48 @@ option (google.api.http) = {
 				},
 			},
 		},
+		{
+			name: "parses nested cloudsetup options",
+			input: `
+option (google.api.http) = {
+    post: "/v1/resources",
+    additional_bindings: {
+		post: "/v2/resources"
+	};
+};`,
+			permissive: true,
+			wantOption: &parser.Option{
+				OptionName: "(google.api.http)",
+				Constant:   `{post:"/v1/resources",additional_bindings:{post:"/v2/resources"};}`,
+				Meta: meta.Meta{
+					Pos: meta.Position{
+						Offset: 1,
+						Line:   2,
+						Column: 1,
+					},
+				},
+			},
+		},
+		{
+			name: "parses trailing commas in options",
+			input: `
+option (google.api.http) = {
+    post: "/v1/resources",
+    body: "data",
+};`,
+			permissive: true,
+			wantOption: &parser.Option{
+				OptionName: "(google.api.http)",
+				Constant:   `{post:"/v1/resources",body:"data",}`,
+				Meta: meta.Meta{
+					Pos: meta.Position{
+						Offset: 1,
+						Line:   2,
+						Column: 1,
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
The parser reports a lot of protos as broken due to `protoc` being more flexible and forgiving than the official spec suggests.
This PR adds a few of these edge cases, such as:
- Nested support of options
```
            additional_bindings {
                get: "/v1/users/{user_id}/messages/{message_id}"
            }
```
- Alternative syntax for nested options
```
            additional_bindings: {
                get: "/v1/users/{user_id}/messages/{message_id}"
            };
```
- Trailing commas in fields
```
    option (field.fields) = {
      foo: "data",
      bar: "data2",
    };
```

Let me know if any of these require extra data. I will be adding tests for these shortly.