### PR TITLE
Expose error data to external tools.

### DIFF
--- a/internal/lexer/error.go
+++ b/internal/lexer/error.go
@@ -1,15 +1,20 @@
 package lexer
 
 import (
-	"fmt"
 	"runtime"
+
+	"github.com/yoheimuta/go-protoparser/parser/meta"
 )
 
 func (lex *Lexer) unexpected(found, expected string) error {
-	debug := ""
+	err := &meta.Error{
+		Pos:      lex.Pos.Position,
+		Expected: expected,
+		Found:    lex.Text,
+	}
 	if lex.debug {
 		_, file, line, _ := runtime.Caller(1)
-		debug = fmt.Sprintf(" at %s:%d", file, line)
+		err.SetOccured(file, line)
 	}
-	return fmt.Errorf("found %q but expected [%s]%s", found, expected, debug)
+	return err
 }

--- a/internal/lexer/scanner/error.go
+++ b/internal/lexer/scanner/error.go
@@ -1,12 +1,18 @@
 package scanner
 
 import (
-	"fmt"
 	"runtime"
+
+	"github.com/yoheimuta/go-protoparser/parser/meta"
 )
 
 func (s *Scanner) unexpected(found rune, expected string) error {
 	_, file, line, _ := runtime.Caller(1)
-	message := fmt.Sprintf(" at %s:%d", file, line)
-	return fmt.Errorf("found %q but expected [%s]%s", found, expected, message)
+	err := &meta.Error{
+		Pos:      s.pos.Position,
+		Expected: expected,
+		Found:    string(found),
+	}
+	err.SetOccured(file, line)
+	return err
 }

--- a/internal/lexer/scanner/position.go
+++ b/internal/lexer/scanner/position.go
@@ -1,20 +1,14 @@
 package scanner
 
 import (
-	"fmt"
 	"unicode/utf8"
+
+	"github.com/yoheimuta/go-protoparser/parser/meta"
 )
 
 // Position represents a source position.
 type Position struct {
-	// Filename is a name of file, if any
-	Filename string
-	// Offset is a byte offset, starting at 0
-	Offset int
-	// Line is a line number, starting at 1
-	Line int
-	// Column is a column number, starting at 1 (character count per line)
-	Column int
+	meta.Position
 
 	// columns is a map which the key is a line number and the value is a column number.
 	columns map[int]int
@@ -23,21 +17,18 @@ type Position struct {
 // NewPosition creates a new Position.
 func NewPosition() *Position {
 	return &Position{
-		Offset:  0,
-		Line:    1,
-		Column:  1,
+		Position: meta.Position{
+			Offset: 0,
+			Line:   1,
+			Column: 1,
+		},
 		columns: make(map[int]int),
 	}
 }
 
 // String stringify the position.
 func (pos Position) String() string {
-	s := pos.Filename
-	if s == "" {
-		s = "<input>"
-	}
-	s += fmt.Sprintf(":%d:%d", pos.Line, pos.Column)
-	return s
+	return pos.Position.String()
 }
 
 // Advance advances the position value.

--- a/internal/lexer/scanner/scanner_test.go
+++ b/internal/lexer/scanner/scanner_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/yoheimuta/go-protoparser/internal/lexer/scanner"
+	"github.com/yoheimuta/go-protoparser/parser/meta"
 )
 
 func TestScanner_Scan(t *testing.T) {
@@ -36,63 +37,83 @@ func TestScanner_Scan(t *testing.T) {
 					token: scanner.TIDENT,
 					text:  "service",
 					pos: scanner.Position{
-						Offset: 0,
-						Line:   1,
-						Column: 1,
+						Position: meta.Position{
+							Offset: 0,
+							Line:   1,
+							Column: 1,
+						},
 					},
 				},
 				{
 					token: scanner.TIDENT,
 					text:  "s1928",
 					pos: scanner.Position{
-						Offset: 8,
-						Line:   1,
-						Column: 9,
+						Position: meta.Position{
+
+							Offset: 8,
+							Line:   1,
+							Column: 9,
+						},
 					},
 				},
 				{
 					token: scanner.TIDENT,
 					text:  "s_a",
 					pos: scanner.Position{
-						Offset: 14,
-						Line:   1,
-						Column: 15,
+						Position: meta.Position{
+
+							Offset: 14,
+							Line:   1,
+							Column: 15,
+						},
 					},
 				},
 				{
 					token: scanner.TILLEGAL,
 					text:  "1",
 					pos: scanner.Position{
-						Offset: 18,
-						Line:   1,
-						Column: 19,
+						Position: meta.Position{
+
+							Offset: 18,
+							Line:   1,
+							Column: 19,
+						},
 					},
 				},
 				{
 					token: scanner.TIDENT,
 					text:  "ac",
 					pos: scanner.Position{
-						Offset: 19,
-						Line:   1,
-						Column: 20,
+						Position: meta.Position{
+
+							Offset: 19,
+							Line:   1,
+							Column: 20,
+						},
 					},
 				},
 				{
 					token: scanner.TILLEGAL,
 					text:  "-",
 					pos: scanner.Position{
-						Offset: 21,
-						Line:   1,
-						Column: 22,
+						Position: meta.Position{
+
+							Offset: 21,
+							Line:   1,
+							Column: 22,
+						},
 					},
 				},
 				{
 					token: scanner.TIDENT,
 					text:  "_s_a",
 					pos: scanner.Position{
-						Offset: 23,
-						Line:   1,
-						Column: 24,
+						Position: meta.Position{
+
+							Offset: 23,
+							Line:   1,
+							Column: 24,
+						},
 					},
 				},
 			},
@@ -106,45 +127,60 @@ func TestScanner_Scan(t *testing.T) {
 					token: scanner.TBOOLLIT,
 					text:  "true",
 					pos: scanner.Position{
-						Offset: 0,
-						Line:   1,
-						Column: 1,
+						Position: meta.Position{
+
+							Offset: 0,
+							Line:   1,
+							Column: 1,
+						},
 					},
 				},
 				{
 					token: scanner.TDOT,
 					text:  ".",
 					pos: scanner.Position{
-						Offset: 4,
-						Line:   1,
-						Column: 5,
+						Position: meta.Position{
+
+							Offset: 4,
+							Line:   1,
+							Column: 5,
+						},
 					},
 				},
 				{
 					token: scanner.TBOOLLIT,
 					text:  "false",
 					pos: scanner.Position{
-						Offset: 5,
-						Line:   1,
-						Column: 6,
+						Position: meta.Position{
+
+							Offset: 5,
+							Line:   1,
+							Column: 6,
+						},
 					},
 				},
 				{
 					token: scanner.TCOMMA,
 					text:  ",",
 					pos: scanner.Position{
-						Offset: 10,
-						Line:   1,
-						Column: 11,
+						Position: meta.Position{
+
+							Offset: 10,
+							Line:   1,
+							Column: 11,
+						},
 					},
 				},
 				{
 					token: scanner.TIDENT,
 					text:  "talse",
 					pos: scanner.Position{
-						Offset: 11,
-						Line:   1,
-						Column: 12,
+						Position: meta.Position{
+
+							Offset: 11,
+							Line:   1,
+							Column: 12,
+						},
 					},
 				},
 			},
@@ -158,27 +194,36 @@ func TestScanner_Scan(t *testing.T) {
 					token: scanner.TIDENT,
 					text:  "true",
 					pos: scanner.Position{
-						Offset: 0,
-						Line:   1,
-						Column: 1,
+						Position: meta.Position{
+
+							Offset: 0,
+							Line:   1,
+							Column: 1,
+						},
 					},
 				},
 				{
 					token: scanner.TSERVICE,
 					text:  "service",
 					pos: scanner.Position{
-						Offset: 5,
-						Line:   1,
-						Column: 6,
+						Position: meta.Position{
+
+							Offset: 5,
+							Line:   1,
+							Column: 6,
+						},
 					},
 				},
 				{
 					token: scanner.TRPC,
 					text:  "rpc",
 					pos: scanner.Position{
-						Offset: 13,
-						Line:   1,
-						Column: 14,
+						Position: meta.Position{
+
+							Offset: 13,
+							Line:   1,
+							Column: 14,
+						},
 					},
 				},
 			},
@@ -200,27 +245,36 @@ fugafuga
 					token: scanner.TCOMMENT,
 					text:  "// hogehoge",
 					pos: scanner.Position{
-						Offset: 1,
-						Line:   2,
-						Column: 1,
+						Position: meta.Position{
+
+							Offset: 1,
+							Line:   2,
+							Column: 1,
+						},
 					},
 				},
 				{
 					token: scanner.TIDENT,
 					text:  "hogehoge",
 					pos: scanner.Position{
-						Offset: 13,
-						Line:   3,
-						Column: 1,
+						Position: meta.Position{
+
+							Offset: 13,
+							Line:   3,
+							Column: 1,
+						},
 					},
 				},
 				{
 					token: scanner.TCOMMENT,
 					text:  "//",
 					pos: scanner.Position{
-						Offset: 22,
-						Line:   4,
-						Column: 1,
+						Position: meta.Position{
+
+							Offset: 22,
+							Line:   4,
+							Column: 1,
+						},
 					},
 				},
 				{
@@ -229,18 +283,24 @@ fugafuga
 fugafuga
 */`,
 					pos: scanner.Position{
-						Offset: 25,
-						Line:   5,
-						Column: 1,
+						Position: meta.Position{
+
+							Offset: 25,
+							Line:   5,
+							Column: 1,
+						},
 					},
 				},
 				{
 					token: scanner.TCOMMENT,
 					text:  "/**/",
 					pos: scanner.Position{
-						Offset: 40,
-						Line:   8,
-						Column: 1,
+						Position: meta.Position{
+
+							Offset: 40,
+							Line:   8,
+							Column: 1,
+						},
 					},
 				},
 			},
@@ -254,54 +314,72 @@ fugafuga
 					token: scanner.TSTRLIT,
 					text:  `""`,
 					pos: scanner.Position{
-						Offset: 0,
-						Line:   1,
-						Column: 1,
+						Position: meta.Position{
+
+							Offset: 0,
+							Line:   1,
+							Column: 1,
+						},
 					},
 				},
 				{
 					token: scanner.TSTRLIT,
 					text:  `''`,
 					pos: scanner.Position{
-						Offset: 3,
-						Line:   1,
-						Column: 4,
+						Position: meta.Position{
+
+							Offset: 3,
+							Line:   1,
+							Column: 4,
+						},
 					},
 				},
 				{
 					token: scanner.TSTRLIT,
 					text:  `"abc"`,
 					pos: scanner.Position{
-						Offset: 6,
-						Line:   1,
-						Column: 7,
+						Position: meta.Position{
+
+							Offset: 6,
+							Line:   1,
+							Column: 7,
+						},
 					},
 				},
 				{
 					token: scanner.TSTRLIT,
 					text:  `'あいう'`,
 					pos: scanner.Position{
-						Offset: 12,
-						Line:   1,
-						Column: 13,
+						Position: meta.Position{
+
+							Offset: 12,
+							Line:   1,
+							Column: 13,
+						},
 					},
 				},
 				{
 					token: scanner.TSTRLIT,
 					text:  `"\x1fzz"`,
 					pos: scanner.Position{
-						Offset: 24,
-						Line:   1,
-						Column: 19,
+						Position: meta.Position{
+
+							Offset: 24,
+							Line:   1,
+							Column: 19,
+						},
 					},
 				},
 				{
 					token: scanner.TSTRLIT,
 					text:  `'\123\n\\'`,
 					pos: scanner.Position{
-						Offset: 33,
-						Line:   1,
-						Column: 28,
+						Position: meta.Position{
+
+							Offset: 33,
+							Line:   1,
+							Column: 28,
+						},
 					},
 				},
 			},
@@ -315,63 +393,84 @@ fugafuga
 					token: scanner.TINTLIT,
 					text:  "1",
 					pos: scanner.Position{
-						Offset: 0,
-						Line:   1,
-						Column: 1,
+						Position: meta.Position{
+
+							Offset: 0,
+							Line:   1,
+							Column: 1,
+						},
 					},
 				},
 				{
 					token: scanner.TINTLIT,
 					text:  "10",
 					pos: scanner.Position{
-						Offset: 2,
-						Line:   1,
-						Column: 3,
+						Position: meta.Position{
+
+							Offset: 2,
+							Line:   1,
+							Column: 3,
+						},
 					},
 				},
 				{
 					token: scanner.TINTLIT,
 					text:  "9999",
 					pos: scanner.Position{
-						Offset: 5,
-						Line:   1,
-						Column: 6,
+						Position: meta.Position{
+
+							Offset: 5,
+							Line:   1,
+							Column: 6,
+						},
 					},
 				},
 				{
 					token: scanner.TINTLIT,
 					text:  "07",
 					pos: scanner.Position{
-						Offset: 10,
-						Line:   1,
-						Column: 11,
+						Position: meta.Position{
+
+							Offset: 10,
+							Line:   1,
+							Column: 11,
+						},
 					},
 				},
 				{
 					token: scanner.TINTLIT,
 					text:  "0123",
 					pos: scanner.Position{
-						Offset: 13,
-						Line:   1,
-						Column: 14,
+						Position: meta.Position{
+
+							Offset: 13,
+							Line:   1,
+							Column: 14,
+						},
 					},
 				},
 				{
 					token: scanner.TINTLIT,
 					text:  "0xf",
 					pos: scanner.Position{
-						Offset: 18,
-						Line:   1,
-						Column: 19,
+						Position: meta.Position{
+
+							Offset: 18,
+							Line:   1,
+							Column: 19,
+						},
 					},
 				},
 				{
 					token: scanner.TINTLIT,
 					text:  "0X123",
 					pos: scanner.Position{
-						Offset: 22,
-						Line:   1,
-						Column: 23,
+						Position: meta.Position{
+
+							Offset: 22,
+							Line:   1,
+							Column: 23,
+						},
 					},
 				},
 			},
@@ -385,99 +484,132 @@ fugafuga
 					token: scanner.TFLOATLIT,
 					text:  "1.0",
 					pos: scanner.Position{
-						Offset: 0,
-						Line:   1,
-						Column: 1,
+						Position: meta.Position{
+
+							Offset: 0,
+							Line:   1,
+							Column: 1,
+						},
 					},
 				},
 				{
 					token: scanner.TFLOATLIT,
 					text:  "99.9",
 					pos: scanner.Position{
-						Offset: 4,
-						Line:   1,
-						Column: 5,
+						Position: meta.Position{
+
+							Offset: 4,
+							Line:   1,
+							Column: 5,
+						},
 					},
 				},
 				{
 					token: scanner.TFLOATLIT,
 					text:  "99.999",
 					pos: scanner.Position{
-						Offset: 9,
-						Line:   1,
-						Column: 10,
+						Position: meta.Position{
+
+							Offset: 9,
+							Line:   1,
+							Column: 10,
+						},
 					},
 				},
 				{
 					token: scanner.TFLOATLIT,
 					text:  "0.11",
 					pos: scanner.Position{
-						Offset: 16,
-						Line:   1,
-						Column: 17,
+						Position: meta.Position{
+
+							Offset: 16,
+							Line:   1,
+							Column: 17,
+						},
 					},
 				},
 				{
 					token: scanner.TFLOATLIT,
 					text:  ".101",
 					pos: scanner.Position{
-						Offset: 21,
-						Line:   1,
-						Column: 22,
+						Position: meta.Position{
+
+							Offset: 21,
+							Line:   1,
+							Column: 22,
+						},
 					},
 				},
 				{
 					token: scanner.TFLOATLIT,
 					text:  "1.234e5",
 					pos: scanner.Position{
-						Offset: 26,
-						Line:   1,
-						Column: 27,
+						Position: meta.Position{
+
+							Offset: 26,
+							Line:   1,
+							Column: 27,
+						},
 					},
 				},
 				{
 					token: scanner.TFLOATLIT,
 					text:  "1928e10",
 					pos: scanner.Position{
-						Offset: 34,
-						Line:   1,
-						Column: 35,
+						Position: meta.Position{
+
+							Offset: 34,
+							Line:   1,
+							Column: 35,
+						},
 					},
 				},
 				{
 					token: scanner.TFLOATLIT,
 					text:  "100.234E+15",
 					pos: scanner.Position{
-						Offset: 42,
-						Line:   1,
-						Column: 43,
+						Position: meta.Position{
+
+							Offset: 42,
+							Line:   1,
+							Column: 43,
+						},
 					},
 				},
 				{
 					token: scanner.TFLOATLIT,
 					text:  "1.234e-5",
 					pos: scanner.Position{
-						Offset: 54,
-						Line:   1,
-						Column: 55,
+						Position: meta.Position{
+
+							Offset: 54,
+							Line:   1,
+							Column: 55,
+						},
 					},
 				},
 				{
 					token: scanner.TFLOATLIT,
 					text:  "inf",
 					pos: scanner.Position{
-						Offset: 63,
-						Line:   1,
-						Column: 64,
+						Position: meta.Position{
+
+							Offset: 63,
+							Line:   1,
+							Column: 64,
+						},
 					},
 				},
 				{
 					token: scanner.TFLOATLIT,
 					text:  "nan",
 					pos: scanner.Position{
-						Offset: 67,
-						Line:   1,
-						Column: 68,
+						Position: meta.Position{
+
+							Offset: 67,
+							Line:   1,
+							Column: 68,
+						},
 					},
 				},
 			},

--- a/parser/comment.go
+++ b/parser/comment.go
@@ -65,7 +65,7 @@ func (p *Parser) parseComment() (*Comment, error) {
 	if p.lex.Token == scanner.TCOMMENT {
 		return &Comment{
 			Raw:  p.lex.Text,
-			Meta: meta.NewMeta(p.lex.Pos),
+			Meta: meta.Meta{Pos: p.lex.Pos.Position},
 		}, nil
 	}
 	defer p.lex.UnNext()

--- a/parser/enum.go
+++ b/parser/enum.go
@@ -127,7 +127,10 @@ func (p *Parser) ParseEnum() (*Enum, error) {
 		EnumName:                     enumName,
 		EnumBody:                     enumBody,
 		InlineCommentBehindLeftCurly: inlineLeftCurly,
-		Meta:                         meta.NewMetaWithLastPos(startPos, lastPos),
+		Meta: meta.Meta{
+			Pos:     startPos.Position,
+			LastPos: lastPos.Position,
+		},
 	}, nil
 }
 
@@ -254,7 +257,7 @@ func (p *Parser) parseEnumField() (*EnumField, error) {
 		Ident:            ident,
 		Number:           number,
 		EnumValueOptions: enumValueOptions,
-		Meta:             meta.NewMeta(startPos),
+		Meta:             meta.Meta{Pos: startPos.Position},
 	}, nil
 }
 

--- a/parser/error.go
+++ b/parser/error.go
@@ -3,12 +3,19 @@ package parser
 import (
 	"fmt"
 	"runtime"
+
+	"github.com/yoheimuta/go-protoparser/parser/meta"
 )
 
 func (p *Parser) unexpected(expected string) error {
 	_, file, line, _ := runtime.Caller(1)
-	msg := fmt.Sprintf(" at %s:%d", file, line)
-	return fmt.Errorf("found %q(Token=%v, Pos=%s) but expected [%s]%s", p.lex.Text, p.lex.Token, p.lex.Pos, expected, msg)
+	err := &meta.Error{
+		Pos:      p.lex.Pos.Position,
+		Expected: expected,
+		Found:    fmt.Sprintf("%q(Token=%v, Pos=%s)", p.lex.Text, p.lex.Token, p.lex.Pos),
+	}
+	err.SetOccured(file, line)
+	return err
 }
 
 func (p *Parser) unexpectedf(

--- a/parser/extend.go
+++ b/parser/extend.go
@@ -87,7 +87,10 @@ func (p *Parser) ParseExtend() (*Extend, error) {
 		MessageType:                  messageType,
 		ExtendBody:                   extendBody,
 		InlineCommentBehindLeftCurly: inlineLeftCurly,
-		Meta:                         meta.NewMetaWithLastPos(startPos, lastPos),
+		Meta: meta.Meta{
+			Pos:     startPos.Position,
+			LastPos: lastPos.Position,
+		},
 	}, nil
 }
 

--- a/parser/extensions.go
+++ b/parser/extensions.go
@@ -59,6 +59,6 @@ func (p *Parser) ParseExtensions() (*Extensions, error) {
 
 	return &Extensions{
 		Ranges: ranges,
-		Meta:   meta.NewMeta(startPos),
+		Meta:   meta.Meta{Pos: startPos.Position},
 	}, nil
 }

--- a/parser/field.go
+++ b/parser/field.go
@@ -110,7 +110,7 @@ func (p *Parser) ParseField() (*Field, error) {
 		FieldName:    fieldName,
 		FieldNumber:  fieldNumber,
 		FieldOptions: fieldOptions,
-		Meta:         meta.NewMeta(startPos),
+		Meta:         meta.Meta{Pos: startPos.Position},
 	}, nil
 }
 

--- a/parser/groupField.go
+++ b/parser/groupField.go
@@ -113,7 +113,10 @@ func (p *Parser) ParseGroupField() (*GroupField, error) {
 		MessageBody: messageBody,
 
 		InlineCommentBehindLeftCurly: inlineLeftCurly,
-		Meta:                         meta.NewMetaWithLastPos(startPos, lastPos),
+		Meta: meta.Meta{
+			Pos:     startPos.Position,
+			LastPos: lastPos.Position,
+		},
 	}, nil
 }
 

--- a/parser/import.go
+++ b/parser/import.go
@@ -84,6 +84,6 @@ func (p *Parser) ParseImport() (*Import, error) {
 	return &Import{
 		Modifier: modifier,
 		Location: location,
-		Meta:     meta.NewMeta(startPos),
+		Meta:     meta.Meta{Pos: startPos.Position},
 	}, nil
 }

--- a/parser/mapField.go
+++ b/parser/mapField.go
@@ -108,7 +108,7 @@ func (p *Parser) ParseMapField() (*MapField, error) {
 		MapName:      mapName,
 		FieldNumber:  fieldNumber,
 		FieldOptions: fieldOptions,
-		Meta:         meta.NewMeta(startPos),
+		Meta:         meta.Meta{Pos: startPos.Position},
 	}, nil
 }
 

--- a/parser/message.go
+++ b/parser/message.go
@@ -88,7 +88,10 @@ func (p *Parser) ParseMessage() (*Message, error) {
 		MessageName:                  messageName,
 		MessageBody:                  messageBody,
 		InlineCommentBehindLeftCurly: inlineLeftCurly,
-		Meta:                         meta.NewMetaWithLastPos(startPos, lastPos),
+		Meta: meta.Meta{
+			Pos:     startPos.Position,
+			LastPos: lastPos.Position,
+		},
 	}, nil
 }
 

--- a/parser/meta/error.go
+++ b/parser/meta/error.go
@@ -16,9 +16,9 @@ type Error struct {
 
 func (e *Error) Error() string {
 	if e.occuredAt == 0 && e.occuredIn == "" {
-		return fmt.Sprintf("found %s but expected [%s]", e.Found, e.Expected)
+		return fmt.Sprintf("found %q but expected [%s]", e.Found, e.Expected)
 	}
-	return fmt.Sprintf("found %s but expected [%s] at %s:%d", e.Found, e.Expected, e.occuredIn, e.occuredAt)
+	return fmt.Sprintf("found %q but expected [%s] at %s:%d", e.Found, e.Expected, e.occuredIn, e.occuredAt)
 }
 
 // SetOccured sets the file and the line number at which the error was raised (through runtime.Caller).

--- a/parser/meta/error.go
+++ b/parser/meta/error.go
@@ -4,6 +4,7 @@ package meta
 
 import "fmt"
 
+// Error is the error type returned for all scanning/lexing/parsing related errors.
 type Error struct {
 	Pos      Position
 	Expected string
@@ -20,6 +21,7 @@ func (e *Error) Error() string {
 	return fmt.Sprintf("found %s but expected [%s] at %s:%d", e.Found, e.Expected, e.occuredIn, e.occuredAt)
 }
 
+// SetOccured sets the file and the line number at which the error was raised (through runtime.Caller).
 func (e *Error) SetOccured(occuredIn string, occuredAt int) {
 	e.occuredIn = occuredIn
 	e.occuredAt = occuredAt

--- a/parser/meta/error.go
+++ b/parser/meta/error.go
@@ -1,0 +1,26 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+package meta
+
+import "fmt"
+
+type Error struct {
+	Pos      Position
+	Expected string
+	Found    string
+
+	occuredIn string
+	occuredAt int
+}
+
+func (e *Error) Error() string {
+	if e.occuredAt == 0 && e.occuredIn == "" {
+		return fmt.Sprintf("found %s but expected [%s]", e.Found, e.Expected)
+	}
+	return fmt.Sprintf("found %s but expected [%s] at %s:%d", e.Found, e.Expected, e.occuredIn, e.occuredAt)
+}
+
+func (e *Error) SetOccured(occuredIn string, occuredAt int) {
+	e.occuredIn = occuredIn
+	e.occuredAt = occuredAt
+}

--- a/parser/meta/meta.go
+++ b/parser/meta/meta.go
@@ -1,7 +1,5 @@
 package meta
 
-import "github.com/yoheimuta/go-protoparser/internal/lexer/scanner"
-
 // Meta represents a meta information about the parsed element.
 type Meta struct {
 	// Pos is the source position.
@@ -9,22 +7,4 @@ type Meta struct {
 	// LastPos is the last source position.
 	// Currently it is set when the parsed element type is message, enum, oneof, rpc or service.
 	LastPos Position
-}
-
-// NewMeta creates a new Meta from scanner.Position.
-func NewMeta(fromPos scanner.Position) Meta {
-	return Meta{
-		Pos: NewPosition(fromPos),
-	}
-}
-
-// NewMetaWithLastPos creates a new Meta with LastPos from scanner.Position.
-func NewMetaWithLastPos(
-	fromPos scanner.Position,
-	fromLastPos scanner.Position,
-) Meta {
-	return Meta{
-		Pos:     NewPosition(fromPos),
-		LastPos: NewPosition(fromLastPos),
-	}
 }

--- a/parser/meta/position.go
+++ b/parser/meta/position.go
@@ -2,8 +2,6 @@ package meta
 
 import (
 	"fmt"
-
-	"github.com/yoheimuta/go-protoparser/internal/lexer/scanner"
 )
 
 // Position represents a source position.
@@ -16,16 +14,6 @@ type Position struct {
 	Line int
 	// Column is a column number, starting at 1 (character count per line)
 	Column int
-}
-
-// NewPosition creates a new Position from scanner.Position.
-func NewPosition(from scanner.Position) Position {
-	return Position{
-		Filename: from.Filename,
-		Offset:   from.Offset,
-		Line:     from.Line,
-		Column:   from.Column,
-	}
 }
 
 // String stringify the position.

--- a/parser/oneof.go
+++ b/parser/oneof.go
@@ -159,7 +159,10 @@ func (p *Parser) ParseOneof() (*Oneof, error) {
 		OneofName:                    oneofName,
 		Options:                      options,
 		InlineCommentBehindLeftCurly: inlineLeftCurly,
-		Meta:                         meta.NewMetaWithLastPos(startPos, lastPos),
+		Meta: meta.Meta{
+			Pos:     startPos.Position,
+			LastPos: lastPos.Position,
+		},
 	}, nil
 }
 
@@ -202,6 +205,6 @@ func (p *Parser) parseOneofField() (*OneofField, error) {
 		FieldName:    fieldName,
 		FieldNumber:  fieldNumber,
 		FieldOptions: fieldOptions,
-		Meta:         meta.NewMeta(startPos),
+		Meta:         meta.Meta{Pos: startPos.Position},
 	}, nil
 }

--- a/parser/option.go
+++ b/parser/option.go
@@ -71,7 +71,7 @@ func (p *Parser) ParseOption() (*Option, error) {
 	return &Option{
 		OptionName: optionName,
 		Constant:   constant,
-		Meta:       meta.NewMeta(startPos),
+		Meta:       meta.Meta{Pos: startPos.Position},
 	}, nil
 }
 

--- a/parser/package.go
+++ b/parser/package.go
@@ -59,6 +59,6 @@ func (p *Parser) ParsePackage() (*Package, error) {
 
 	return &Package{
 		Name: ident,
-		Meta: meta.NewMeta(startPos),
+		Meta: meta.Meta{Pos: startPos.Position},
 	}, nil
 }

--- a/parser/reserved.go
+++ b/parser/reserved.go
@@ -96,7 +96,7 @@ func (p *Parser) ParseReserved() (*Reserved, error) {
 	return &Reserved{
 		Ranges:     ranges,
 		FieldNames: fieldNames,
-		Meta:       meta.NewMeta(startPos),
+		Meta:       meta.Meta{Pos: startPos.Position},
 	}, nil
 }
 

--- a/parser/service.go
+++ b/parser/service.go
@@ -124,7 +124,10 @@ func (p *Parser) ParseService() (*Service, error) {
 		ServiceName:                  serviceName,
 		ServiceBody:                  serviceBody,
 		InlineCommentBehindLeftCurly: inlineLeftCurly,
-		Meta:                         meta.NewMetaWithLastPos(startPos, lastPos),
+		Meta: meta.Meta{
+			Pos:     startPos.Position,
+			LastPos: lastPos.Position,
+		},
 	}, nil
 }
 
@@ -260,7 +263,10 @@ func (p *Parser) parseRPC() (*RPC, error) {
 		RPCRequest:  rpcRequest,
 		RPCResponse: rpcResponse,
 		Options:     opts,
-		Meta:        meta.NewMetaWithLastPos(startPos, lastPos),
+		Meta: meta.Meta{
+			Pos:     startPos.Position,
+			LastPos: lastPos.Position,
+		},
 	}, nil
 }
 
@@ -293,7 +299,7 @@ func (p *Parser) parseRPCRequest() (*RPCRequest, error) {
 	return &RPCRequest{
 		IsStream:    isStream,
 		MessageType: messageType,
-		Meta:        meta.NewMeta(startPos),
+		Meta:        meta.Meta{Pos: startPos.Position},
 	}, nil
 }
 
@@ -326,7 +332,7 @@ func (p *Parser) parseRPCResponse() (*RPCResponse, error) {
 	return &RPCResponse{
 		IsStream:    isStream,
 		MessageType: messageType,
-		Meta:        meta.NewMeta(startPos),
+		Meta:        meta.Meta{Pos: startPos.Position},
 	}, nil
 }
 

--- a/parser/syntax.go
+++ b/parser/syntax.go
@@ -88,6 +88,6 @@ func (p *Parser) ParseSyntax() (*Syntax, error) {
 
 	return &Syntax{
 		ProtobufVersion: version,
-		Meta:            meta.NewMeta(startPos),
+		Meta:            meta.Meta{Pos: startPos.Position},
 	}, nil
 }


### PR DESCRIPTION
This creates a specific error type which can be used for error handling in other tools (eg protolint) instead of the current `fmt.Errorf()` setup.

Before merging, it should be decided whether we expect each component (scanner/lexer/parser) to have its own specific error type, or if one is enough.
The current design uses a single error type, to avoid extra boilerplate on external tools having to check multiple errors, and because they all seem to return the same (or very similar) data. 


Let me know if you have any strong opinions regarding each option.

(And sorry for the large PR, most of it is boilerplate test code that needed editing😅)