### PR TITLE
Update gomod file to point to /v4, as defined by gomod standard.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-# go-protoparser [![GoDoc](https://godoc.org/github.com/yoheimuta/go-protoparser?status.svg)](https://godoc.org/github.com/yoheimuta/go-protoparser)[![CircleCI](https://circleci.com/gh/yoheimuta/go-protoparser/tree/master.svg?style=svg)](https://circleci.com/gh/yoheimuta/go-protoparser/tree/master)[![Go Report Card](https://goreportcard.com/badge/github.com/yoheimuta/go-protoparser)](https://goreportcard.com/report/github.com/yoheimuta/go-protoparser)[![Release](http://img.shields.io/github/release/yoheimuta/go-protoparser.svg?style=flat)](https://github.com/yoheimuta/go-protoparser/releases/latest)[![License](http://img.shields.io/:license-mit-blue.svg)](https://github.com/yoheimuta/go-protoparser/blob/master/LICENSE.md)
+# go-protoparser [![GoDoc](https://godoc.org/github.com/yoheimuta/go-protoparser/v4?status.svg)](https://godoc.org/github.com/yoheimuta/go-protoparser/v4)[![CircleCI](https://circleci.com/gh/yoheimuta/go-protoparser/tree/master.svg?style=svg)](https://circleci.com/gh/yoheimuta/go-protoparser/tree/master)[![Go Report Card](https://goreportcard.com/badge/github.com/yoheimuta/go-protoparser/v4)](https://goreportcard.com/report/github.com/yoheimuta/go-protoparser/v4)[![Release](http://img.shields.io/github/release/yoheimuta/go-protoparser.svg?style=flat)](https://github.com/yoheimuta/go-protoparser/releases/latest)[![License](http://img.shields.io/:license-mit-blue.svg)](https://github.com/yoheimuta/go-protoparser/blob/master/LICENSE.md)
 
 go-protoparser is a yet another Go package which parses a Protocol Buffer file (proto2+proto3).
 
 - Conforms to the exactly [official spec](https://developers.google.com/protocol-buffers/docs/reference/proto3-spec).
 - Undergone rigorous testing. The parser can parses all examples of the official spec well.
-- Easy to use the parser. You can just call the [Parse function](https://godoc.org/github.com/yoheimuta/go-protoparser#Parse) and receive the [Proto struct](https://godoc.org/github.com/yoheimuta/go-protoparser/parser#Proto).
-  - If you don't care about the order of body elements, consider to use the [unordered.Proto struct](https://godoc.org/github.com/yoheimuta/go-protoparser/interpret/unordered#Proto).
-  - Or if you want to use the visitor pattern, use the [Visitor struct](https://godoc.org/github.com/yoheimuta/go-protoparser/parser#Visitor).
+- Easy to use the parser. You can just call the [Parse function](https://godoc.org/github.com/yoheimuta/go-protoparser/v4#Parse) and receive the [Proto struct](https://godoc.org/github.com/yoheimuta/go-protoparser/v4/parser#Proto).
+  - If you don't care about the order of body elements, consider to use the [unordered.Proto struct](https://godoc.org/github.com/yoheimuta/go-protoparser/v4/interpret/unordered#Proto).
+  - Or if you want to use the visitor pattern, use the [Visitor struct](https://godoc.org/github.com/yoheimuta/go-protoparser/v4/parser#Visitor).
 
 ### Installation
 
 ```
-go get github.com/yoheimuta/go-protoparser
+go get github.com/yoheimuta/go-protoparser/v4
 ```
 
 ### Example

--- a/_example/dump/main.go
+++ b/_example/dump/main.go
@@ -8,7 +8,7 @@ import (
 
 	"path/filepath"
 
-	protoparser "github.com/yoheimuta/go-protoparser"
+	protoparser "github.com/yoheimuta/go-protoparser/v4"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/yoheimuta/go-protoparser
+module github.com/yoheimuta/go-protoparser/v4
 
 go 1.13

--- a/internal/lexer/constant.go
+++ b/internal/lexer/constant.go
@@ -3,7 +3,7 @@ package lexer
 import (
 	"strings"
 
-	"github.com/yoheimuta/go-protoparser/internal/lexer/scanner"
+	"github.com/yoheimuta/go-protoparser/v4/internal/lexer/scanner"
 )
 
 // ReadConstant reads a constant. If permissive is true, accepts multiline string literals.

--- a/internal/lexer/constant_test.go
+++ b/internal/lexer/constant_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/yoheimuta/go-protoparser/internal/lexer"
+	"github.com/yoheimuta/go-protoparser/v4/internal/lexer"
 )
 
 func TestLexer2_ReadConstant(t *testing.T) {

--- a/internal/lexer/emptyStatement.go
+++ b/internal/lexer/emptyStatement.go
@@ -1,6 +1,6 @@
 package lexer
 
-import "github.com/yoheimuta/go-protoparser/internal/lexer/scanner"
+import "github.com/yoheimuta/go-protoparser/v4/internal/lexer/scanner"
 
 // ReadEmptyStatement reads an emptyStatement.
 //  emptyStatement = ";"

--- a/internal/lexer/emptyStatement_test.go
+++ b/internal/lexer/emptyStatement_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/yoheimuta/go-protoparser/internal/lexer"
+	"github.com/yoheimuta/go-protoparser/v4/internal/lexer"
 )
 
 func TestLexer2_ReadEmptyStatement(t *testing.T) {

--- a/internal/lexer/enumType.go
+++ b/internal/lexer/enumType.go
@@ -1,6 +1,6 @@
 package lexer
 
-import "github.com/yoheimuta/go-protoparser/internal/lexer/scanner"
+import "github.com/yoheimuta/go-protoparser/v4/internal/lexer/scanner"
 
 // ReadEnumType reads a messageType.
 // enumType = [ "." ] { ident "." } enumName

--- a/internal/lexer/enumType_test.go
+++ b/internal/lexer/enumType_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/yoheimuta/go-protoparser/internal/lexer"
+	"github.com/yoheimuta/go-protoparser/v4/internal/lexer"
 )
 
 func TestLexer2_ReadEnumType(t *testing.T) {

--- a/internal/lexer/error.go
+++ b/internal/lexer/error.go
@@ -3,7 +3,7 @@ package lexer
 import (
 	"runtime"
 
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 )
 
 func (lex *Lexer) unexpected(found, expected string) error {

--- a/internal/lexer/fullIdent.go
+++ b/internal/lexer/fullIdent.go
@@ -1,6 +1,6 @@
 package lexer
 
-import "github.com/yoheimuta/go-protoparser/internal/lexer/scanner"
+import "github.com/yoheimuta/go-protoparser/v4/internal/lexer/scanner"
 
 // ReadFullIdent reads a fullIdent.
 // fullIdent = ident { "." ident }

--- a/internal/lexer/fullIdent_test.go
+++ b/internal/lexer/fullIdent_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/yoheimuta/go-protoparser/internal/lexer"
+	"github.com/yoheimuta/go-protoparser/v4/internal/lexer"
 )
 
 func TestLexer2_ReadFullIdent(t *testing.T) {

--- a/internal/lexer/lexer.go
+++ b/internal/lexer/lexer.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/yoheimuta/go-protoparser/internal/lexer/scanner"
+	"github.com/yoheimuta/go-protoparser/v4/internal/lexer/scanner"
 )
 
 // Lexer is a lexer.

--- a/internal/lexer/messageType.go
+++ b/internal/lexer/messageType.go
@@ -1,6 +1,6 @@
 package lexer
 
-import "github.com/yoheimuta/go-protoparser/internal/lexer/scanner"
+import "github.com/yoheimuta/go-protoparser/v4/internal/lexer/scanner"
 
 // ReadMessageType reads a messageType.
 // messageType = [ "." ] { ident "." } messageName

--- a/internal/lexer/messageType_test.go
+++ b/internal/lexer/messageType_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/yoheimuta/go-protoparser/internal/lexer"
+	"github.com/yoheimuta/go-protoparser/v4/internal/lexer"
 )
 
 func TestLexer2_ReadMessageType(t *testing.T) {

--- a/internal/lexer/scanner/error.go
+++ b/internal/lexer/scanner/error.go
@@ -3,7 +3,7 @@ package scanner
 import (
 	"runtime"
 
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 )
 
 func (s *Scanner) unexpected(found rune, expected string) error {

--- a/internal/lexer/scanner/position.go
+++ b/internal/lexer/scanner/position.go
@@ -3,7 +3,7 @@ package scanner
 import (
 	"unicode/utf8"
 
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 )
 
 // Position represents a source position.

--- a/internal/lexer/scanner/position_test.go
+++ b/internal/lexer/scanner/position_test.go
@@ -3,7 +3,7 @@ package scanner_test
 import (
 	"testing"
 
-	"github.com/yoheimuta/go-protoparser/internal/lexer/scanner"
+	"github.com/yoheimuta/go-protoparser/v4/internal/lexer/scanner"
 )
 
 func TestPosition_Advance(t *testing.T) {

--- a/internal/lexer/scanner/scanner_test.go
+++ b/internal/lexer/scanner/scanner_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/yoheimuta/go-protoparser/internal/lexer/scanner"
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/internal/lexer/scanner"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 )
 
 func TestScanner_Scan(t *testing.T) {

--- a/interpret/unordered/enum.go
+++ b/interpret/unordered/enum.go
@@ -3,8 +3,8 @@ package unordered
 import (
 	"fmt"
 
-	"github.com/yoheimuta/go-protoparser/parser"
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/parser"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 )
 
 // EnumBody is unordered in nature, but each slice field preserves the original order.

--- a/interpret/unordered/enum_test.go
+++ b/interpret/unordered/enum_test.go
@@ -4,9 +4,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/yoheimuta/go-protoparser/interpret/unordered"
-	"github.com/yoheimuta/go-protoparser/parser"
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/interpret/unordered"
+	"github.com/yoheimuta/go-protoparser/v4/parser"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 )
 
 func TestInterpretEnum(t *testing.T) {

--- a/interpret/unordered/extend.go
+++ b/interpret/unordered/extend.go
@@ -3,8 +3,8 @@ package unordered
 import (
 	"fmt"
 
-	"github.com/yoheimuta/go-protoparser/parser"
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/parser"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 )
 
 // ExtendBody is unordered in nature, but each slice field preserves the original order.

--- a/interpret/unordered/message.go
+++ b/interpret/unordered/message.go
@@ -3,8 +3,8 @@ package unordered
 import (
 	"fmt"
 
-	"github.com/yoheimuta/go-protoparser/parser"
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/parser"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 )
 
 // MessageBody is unordered in nature, but each slice field preserves the original order.

--- a/interpret/unordered/message_test.go
+++ b/interpret/unordered/message_test.go
@@ -4,9 +4,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/yoheimuta/go-protoparser/interpret/unordered"
-	"github.com/yoheimuta/go-protoparser/parser"
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/interpret/unordered"
+	"github.com/yoheimuta/go-protoparser/v4/parser"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 )
 
 func TestInterpretMessage(t *testing.T) {

--- a/interpret/unordered/proto.go
+++ b/interpret/unordered/proto.go
@@ -3,7 +3,7 @@ package unordered
 import (
 	"fmt"
 
-	"github.com/yoheimuta/go-protoparser/parser"
+	"github.com/yoheimuta/go-protoparser/v4/parser"
 )
 
 // ProtoBody is unordered in nature, but each slice field preserves the original order.

--- a/interpret/unordered/proto_test.go
+++ b/interpret/unordered/proto_test.go
@@ -4,8 +4,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/yoheimuta/go-protoparser/interpret/unordered"
-	"github.com/yoheimuta/go-protoparser/parser"
+	"github.com/yoheimuta/go-protoparser/v4/interpret/unordered"
+	"github.com/yoheimuta/go-protoparser/v4/parser"
 )
 
 func TestInterpretProto(t *testing.T) {

--- a/interpret/unordered/service.go
+++ b/interpret/unordered/service.go
@@ -3,8 +3,8 @@ package unordered
 import (
 	"fmt"
 
-	"github.com/yoheimuta/go-protoparser/parser"
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/parser"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 )
 
 // ServiceBody is unordered in nature, but each slice field preserves the original order.

--- a/interpret/unordered/service_test.go
+++ b/interpret/unordered/service_test.go
@@ -4,9 +4,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/yoheimuta/go-protoparser/interpret/unordered"
-	"github.com/yoheimuta/go-protoparser/parser"
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/interpret/unordered"
+	"github.com/yoheimuta/go-protoparser/v4/parser"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 )
 
 func TestInterpretService(t *testing.T) {

--- a/parser/comment.go
+++ b/parser/comment.go
@@ -3,8 +3,8 @@ package parser
 import (
 	"strings"
 
-	"github.com/yoheimuta/go-protoparser/internal/lexer/scanner"
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/internal/lexer/scanner"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 )
 
 const (

--- a/parser/comment_test.go
+++ b/parser/comment_test.go
@@ -5,10 +5,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/yoheimuta/go-protoparser/internal/lexer"
-	"github.com/yoheimuta/go-protoparser/internal/util_test"
-	"github.com/yoheimuta/go-protoparser/parser"
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/internal/lexer"
+	"github.com/yoheimuta/go-protoparser/v4/internal/util_test"
+	"github.com/yoheimuta/go-protoparser/v4/parser"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 )
 
 func TestComment_IsCStyle(t *testing.T) {

--- a/parser/enum.go
+++ b/parser/enum.go
@@ -3,8 +3,8 @@ package parser
 import (
 	"fmt"
 
-	"github.com/yoheimuta/go-protoparser/internal/lexer/scanner"
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/internal/lexer/scanner"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 )
 
 type parseEnumBodyStatementErr struct {
@@ -174,7 +174,7 @@ func (p *Parser) parseEnumBody() (
 
 			lastPos := p.lex.Pos
 			if p.permissive {
-				// accept a block followed by semicolon. See https://github.com/yoheimuta/go-protoparser/issues/30.
+				// accept a block followed by semicolon. See https://github.com/yoheimuta/go-protoparser/v4/issues/30.
 				p.lex.ConsumeToken(scanner.TSEMICOLON)
 				if p.lex.Token == scanner.TSEMICOLON {
 					lastPos = p.lex.Pos

--- a/parser/enum_test.go
+++ b/parser/enum_test.go
@@ -5,10 +5,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/yoheimuta/go-protoparser/internal/lexer"
-	"github.com/yoheimuta/go-protoparser/internal/util_test"
-	"github.com/yoheimuta/go-protoparser/parser"
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/internal/lexer"
+	"github.com/yoheimuta/go-protoparser/v4/internal/util_test"
+	"github.com/yoheimuta/go-protoparser/v4/parser"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 )
 
 func TestParser_ParseEnum(t *testing.T) {

--- a/parser/error.go
+++ b/parser/error.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"runtime"
 
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 )
 
 func (p *Parser) unexpected(expected string) error {

--- a/parser/extend.go
+++ b/parser/extend.go
@@ -3,8 +3,8 @@ package parser
 import (
 	"fmt"
 
-	"github.com/yoheimuta/go-protoparser/internal/lexer/scanner"
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/internal/lexer/scanner"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 )
 
 type parseExtendBodyStatementErr struct {
@@ -113,7 +113,7 @@ func (p *Parser) parseExtendBody() (
 	if p.lex.Token == scanner.TRIGHTCURLY {
 		lastPos := p.lex.Pos
 		if p.permissive {
-			// accept a block followed by semicolon. See https://github.com/yoheimuta/go-protoparser/issues/30.
+			// accept a block followed by semicolon. See https://github.com/yoheimuta/go-protoparser/v4/issues/30.
 			p.lex.ConsumeToken(scanner.TSEMICOLON)
 			if p.lex.Token == scanner.TSEMICOLON {
 				lastPos = p.lex.Pos
@@ -150,7 +150,7 @@ func (p *Parser) parseExtendBody() (
 
 			lastPos := p.lex.Pos
 			if p.permissive {
-				// accept a block followed by semicolon. See https://github.com/yoheimuta/go-protoparser/issues/30.
+				// accept a block followed by semicolon. See https://github.com/yoheimuta/go-protoparser/v4/issues/30.
 				p.lex.ConsumeToken(scanner.TSEMICOLON)
 				if p.lex.Token == scanner.TSEMICOLON {
 					lastPos = p.lex.Pos

--- a/parser/extend_test.go
+++ b/parser/extend_test.go
@@ -5,11 +5,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 
-	"github.com/yoheimuta/go-protoparser/internal/lexer"
-	"github.com/yoheimuta/go-protoparser/internal/util_test"
-	"github.com/yoheimuta/go-protoparser/parser"
+	"github.com/yoheimuta/go-protoparser/v4/internal/lexer"
+	"github.com/yoheimuta/go-protoparser/v4/internal/util_test"
+	"github.com/yoheimuta/go-protoparser/v4/parser"
 )
 
 func TestParser_ParseExtend(t *testing.T) {

--- a/parser/extensions.go
+++ b/parser/extensions.go
@@ -1,8 +1,8 @@
 package parser
 
 import (
-	"github.com/yoheimuta/go-protoparser/internal/lexer/scanner"
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/internal/lexer/scanner"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 )
 
 // Extensions declare that a range of field numbers in a message are available for third-party extensions.

--- a/parser/extensions_test.go
+++ b/parser/extensions_test.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/yoheimuta/go-protoparser/internal/lexer"
-	"github.com/yoheimuta/go-protoparser/parser"
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/internal/lexer"
+	"github.com/yoheimuta/go-protoparser/v4/parser"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 )
 
 func TestParser_ParseExtensions(t *testing.T) {

--- a/parser/field.go
+++ b/parser/field.go
@@ -1,8 +1,8 @@
 package parser
 
 import (
-	"github.com/yoheimuta/go-protoparser/internal/lexer/scanner"
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/internal/lexer/scanner"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 )
 
 // FieldOption is an option for the field.

--- a/parser/field_test.go
+++ b/parser/field_test.go
@@ -5,10 +5,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/yoheimuta/go-protoparser/internal/lexer"
-	"github.com/yoheimuta/go-protoparser/internal/util_test"
-	"github.com/yoheimuta/go-protoparser/parser"
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/internal/lexer"
+	"github.com/yoheimuta/go-protoparser/v4/internal/util_test"
+	"github.com/yoheimuta/go-protoparser/v4/parser"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 )
 
 func TestParser_ParseField(t *testing.T) {

--- a/parser/groupField.go
+++ b/parser/groupField.go
@@ -3,8 +3,8 @@ package parser
 import (
 	"unicode/utf8"
 
-	"github.com/yoheimuta/go-protoparser/internal/lexer/scanner"
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/internal/lexer/scanner"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 )
 
 // GroupField is one way to nest information in message definitions.

--- a/parser/groupField_test.go
+++ b/parser/groupField_test.go
@@ -5,11 +5,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 
-	"github.com/yoheimuta/go-protoparser/internal/lexer"
-	"github.com/yoheimuta/go-protoparser/internal/util_test"
-	"github.com/yoheimuta/go-protoparser/parser"
+	"github.com/yoheimuta/go-protoparser/v4/internal/lexer"
+	"github.com/yoheimuta/go-protoparser/v4/internal/util_test"
+	"github.com/yoheimuta/go-protoparser/v4/parser"
 )
 
 func TestParser_ParseGroupField(t *testing.T) {

--- a/parser/import.go
+++ b/parser/import.go
@@ -1,8 +1,8 @@
 package parser
 
 import (
-	"github.com/yoheimuta/go-protoparser/internal/lexer/scanner"
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/internal/lexer/scanner"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 )
 
 // ImportModifier is a modifier enum type for import behavior.

--- a/parser/import_test.go
+++ b/parser/import_test.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/yoheimuta/go-protoparser/internal/lexer"
-	"github.com/yoheimuta/go-protoparser/parser"
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/internal/lexer"
+	"github.com/yoheimuta/go-protoparser/v4/parser"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 )
 
 func TestParser_ParseImport(t *testing.T) {

--- a/parser/inlineComment_test.go
+++ b/parser/inlineComment_test.go
@@ -5,10 +5,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/yoheimuta/go-protoparser/internal/lexer"
-	"github.com/yoheimuta/go-protoparser/internal/util_test"
-	"github.com/yoheimuta/go-protoparser/parser"
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/internal/lexer"
+	"github.com/yoheimuta/go-protoparser/v4/internal/util_test"
+	"github.com/yoheimuta/go-protoparser/v4/parser"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 )
 
 type mockHasInlineCommentSetter struct {

--- a/parser/mapField.go
+++ b/parser/mapField.go
@@ -1,8 +1,8 @@
 package parser
 
 import (
-	"github.com/yoheimuta/go-protoparser/internal/lexer/scanner"
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/internal/lexer/scanner"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 )
 
 // MapField is an associative map.

--- a/parser/mapField_test.go
+++ b/parser/mapField_test.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/yoheimuta/go-protoparser/internal/lexer"
-	"github.com/yoheimuta/go-protoparser/parser"
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/internal/lexer"
+	"github.com/yoheimuta/go-protoparser/v4/parser"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 )
 
 func TestParser_ParseMapField(t *testing.T) {

--- a/parser/message.go
+++ b/parser/message.go
@@ -3,8 +3,8 @@ package parser
 import (
 	"fmt"
 
-	"github.com/yoheimuta/go-protoparser/internal/lexer/scanner"
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/internal/lexer/scanner"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 )
 
 type parseMessageBodyStatementErr struct {
@@ -115,7 +115,7 @@ func (p *Parser) parseMessageBody() (
 	if p.lex.Token == scanner.TRIGHTCURLY {
 		lastPos := p.lex.Pos
 		if p.permissive {
-			// accept a block followed by semicolon. See https://github.com/yoheimuta/go-protoparser/issues/30.
+			// accept a block followed by semicolon. See https://github.com/yoheimuta/go-protoparser/v4/issues/30.
 			p.lex.ConsumeToken(scanner.TSEMICOLON)
 			if p.lex.Token == scanner.TSEMICOLON {
 				lastPos = p.lex.Pos
@@ -152,7 +152,7 @@ func (p *Parser) parseMessageBody() (
 
 			lastPos := p.lex.Pos
 			if p.permissive {
-				// accept a block followed by semicolon. See https://github.com/yoheimuta/go-protoparser/issues/30.
+				// accept a block followed by semicolon. See https://github.com/yoheimuta/go-protoparser/v4/issues/30.
 				p.lex.ConsumeToken(scanner.TSEMICOLON)
 				if p.lex.Token == scanner.TSEMICOLON {
 					lastPos = p.lex.Pos

--- a/parser/message_test.go
+++ b/parser/message_test.go
@@ -5,10 +5,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/yoheimuta/go-protoparser/internal/lexer"
-	"github.com/yoheimuta/go-protoparser/internal/util_test"
-	"github.com/yoheimuta/go-protoparser/parser"
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/internal/lexer"
+	"github.com/yoheimuta/go-protoparser/v4/internal/util_test"
+	"github.com/yoheimuta/go-protoparser/v4/parser"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 )
 
 func TestParser_ParseMessage(t *testing.T) {

--- a/parser/meta/position_test.go
+++ b/parser/meta/position_test.go
@@ -3,7 +3,7 @@ package meta_test
 import (
 	"testing"
 
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 )
 
 func TestPosition_String(t *testing.T) {

--- a/parser/oneof.go
+++ b/parser/oneof.go
@@ -1,8 +1,8 @@
 package parser
 
 import (
-	"github.com/yoheimuta/go-protoparser/internal/lexer/scanner"
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/internal/lexer/scanner"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 )
 
 // OneofField is a constituent field of oneof.
@@ -119,7 +119,7 @@ func (p *Parser) ParseOneof() (*Oneof, error) {
 		token := p.lex.Token
 		p.lex.UnNext()
 		if p.permissive && token == scanner.TOPTION {
-			// accept an option. See https://github.com/yoheimuta/go-protoparser/issues/39.
+			// accept an option. See https://github.com/yoheimuta/go-protoparser/v4/issues/39.
 			option, err := p.ParseOption()
 			if err != nil {
 				return nil, err
@@ -147,7 +147,7 @@ func (p *Parser) ParseOneof() (*Oneof, error) {
 
 	lastPos := p.lex.Pos
 	if p.permissive {
-		// accept a block followed by semicolon. See https://github.com/yoheimuta/go-protoparser/issues/30.
+		// accept a block followed by semicolon. See https://github.com/yoheimuta/go-protoparser/v4/issues/30.
 		p.lex.ConsumeToken(scanner.TSEMICOLON)
 		if p.lex.Token == scanner.TSEMICOLON {
 			lastPos = p.lex.Pos

--- a/parser/oneof_test.go
+++ b/parser/oneof_test.go
@@ -5,10 +5,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/yoheimuta/go-protoparser/internal/lexer"
-	"github.com/yoheimuta/go-protoparser/internal/util_test"
-	"github.com/yoheimuta/go-protoparser/parser"
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/internal/lexer"
+	"github.com/yoheimuta/go-protoparser/v4/internal/util_test"
+	"github.com/yoheimuta/go-protoparser/v4/parser"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 )
 
 func TestParser_ParseOneof(t *testing.T) {
@@ -368,7 +368,7 @@ func TestParser_ParseOneof(t *testing.T) {
 			},
 		},
 		{
-			name: "accept options. See https://github.com/yoheimuta/go-protoparser/issues/39",
+			name: "accept options. See https://github.com/yoheimuta/go-protoparser/v4/issues/39",
 			input: `oneof something {
   option (validator.oneof) = {required: true};
   uint32 three_int = 5 [(validator.field) = {int_gt: 20}];

--- a/parser/option.go
+++ b/parser/option.go
@@ -1,8 +1,8 @@
 package parser
 
 import (
-	"github.com/yoheimuta/go-protoparser/internal/lexer/scanner"
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/internal/lexer/scanner"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 )
 
 // Option can be used in proto files, messages, enums and services.

--- a/parser/option_test.go
+++ b/parser/option_test.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/yoheimuta/go-protoparser/internal/lexer"
-	"github.com/yoheimuta/go-protoparser/parser"
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/internal/lexer"
+	"github.com/yoheimuta/go-protoparser/v4/parser"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 )
 
 func TestParser_ParseOption(t *testing.T) {

--- a/parser/package.go
+++ b/parser/package.go
@@ -1,8 +1,8 @@
 package parser
 
 import (
-	"github.com/yoheimuta/go-protoparser/internal/lexer/scanner"
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/internal/lexer/scanner"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 )
 
 // Package can be used to prevent name clashes between protocol message types.

--- a/parser/package_test.go
+++ b/parser/package_test.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/yoheimuta/go-protoparser/internal/lexer"
-	"github.com/yoheimuta/go-protoparser/parser"
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/internal/lexer"
+	"github.com/yoheimuta/go-protoparser/v4/parser"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 )
 
 func TestParser_ParsePackage(t *testing.T) {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1,6 +1,6 @@
 package parser
 
-import "github.com/yoheimuta/go-protoparser/internal/lexer"
+import "github.com/yoheimuta/go-protoparser/v4/internal/lexer"
 
 // Parser is a parser.
 type Parser struct {

--- a/parser/proto.go
+++ b/parser/proto.go
@@ -1,6 +1,6 @@
 package parser
 
-import "github.com/yoheimuta/go-protoparser/internal/lexer/scanner"
+import "github.com/yoheimuta/go-protoparser/v4/internal/lexer/scanner"
 
 // ProtoMeta represents a meta information about the Proto.
 type ProtoMeta struct {

--- a/parser/proto_accept_test.go
+++ b/parser/proto_accept_test.go
@@ -5,7 +5,7 @@ import (
 
 	"testing"
 
-	"github.com/yoheimuta/go-protoparser/parser"
+	"github.com/yoheimuta/go-protoparser/v4/parser"
 )
 
 type protoTestVisitor struct {

--- a/parser/proto_test.go
+++ b/parser/proto_test.go
@@ -5,10 +5,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/yoheimuta/go-protoparser/internal/lexer"
-	"github.com/yoheimuta/go-protoparser/internal/util_test"
-	"github.com/yoheimuta/go-protoparser/parser"
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/internal/lexer"
+	"github.com/yoheimuta/go-protoparser/v4/internal/util_test"
+	"github.com/yoheimuta/go-protoparser/v4/parser"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 )
 
 func TestParser_ParseProto(t *testing.T) {

--- a/parser/reserved.go
+++ b/parser/reserved.go
@@ -3,8 +3,8 @@ package parser
 import (
 	"fmt"
 
-	"github.com/yoheimuta/go-protoparser/internal/lexer/scanner"
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/internal/lexer/scanner"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 )
 
 type parseReservedErr struct {

--- a/parser/reserved_test.go
+++ b/parser/reserved_test.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/yoheimuta/go-protoparser/internal/lexer"
-	"github.com/yoheimuta/go-protoparser/parser"
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/internal/lexer"
+	"github.com/yoheimuta/go-protoparser/v4/parser"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 )
 
 func TestParser_ParseReserved(t *testing.T) {

--- a/parser/service.go
+++ b/parser/service.go
@@ -1,8 +1,8 @@
 package parser
 
 import (
-	"github.com/yoheimuta/go-protoparser/internal/lexer/scanner"
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/internal/lexer/scanner"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 )
 
 // RPCRequest is a request of RPC.
@@ -170,7 +170,7 @@ func (p *Parser) parseServiceBody() (
 
 			lastPos := p.lex.Pos
 			if p.permissive {
-				// accept a block followed by semicolon. See https://github.com/yoheimuta/go-protoparser/issues/30.
+				// accept a block followed by semicolon. See https://github.com/yoheimuta/go-protoparser/v4/issues/30.
 				p.lex.ConsumeToken(scanner.TSEMICOLON)
 				if p.lex.Token == scanner.TSEMICOLON {
 					lastPos = p.lex.Pos
@@ -246,7 +246,7 @@ func (p *Parser) parseRPC() (*RPC, error) {
 		}
 		lastPos = p.lex.Pos
 		if p.permissive {
-			// accept a block followed by semicolon. See https://github.com/yoheimuta/go-protoparser/issues/30.
+			// accept a block followed by semicolon. See https://github.com/yoheimuta/go-protoparser/v4/issues/30.
 			p.lex.ConsumeToken(scanner.TSEMICOLON)
 			if p.lex.Token == scanner.TSEMICOLON {
 				lastPos = p.lex.Pos

--- a/parser/service_test.go
+++ b/parser/service_test.go
@@ -5,10 +5,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/yoheimuta/go-protoparser/internal/lexer"
-	"github.com/yoheimuta/go-protoparser/internal/util_test"
-	"github.com/yoheimuta/go-protoparser/parser"
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/internal/lexer"
+	"github.com/yoheimuta/go-protoparser/v4/internal/util_test"
+	"github.com/yoheimuta/go-protoparser/v4/parser"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 )
 
 func TestParser_ParseService(t *testing.T) {

--- a/parser/syntax.go
+++ b/parser/syntax.go
@@ -1,8 +1,8 @@
 package parser
 
 import (
-	"github.com/yoheimuta/go-protoparser/internal/lexer/scanner"
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/internal/lexer/scanner"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 )
 
 // Syntax is used to define the protobuf version.

--- a/parser/syntax_test.go
+++ b/parser/syntax_test.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/yoheimuta/go-protoparser/internal/lexer"
-	"github.com/yoheimuta/go-protoparser/parser"
-	"github.com/yoheimuta/go-protoparser/parser/meta"
+	"github.com/yoheimuta/go-protoparser/v4/internal/lexer"
+	"github.com/yoheimuta/go-protoparser/v4/parser"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 )
 
 func TestParser_ParseSyntax(t *testing.T) {

--- a/protoparser.go
+++ b/protoparser.go
@@ -3,9 +3,9 @@ package protoparser
 import (
 	"io"
 
-	"github.com/yoheimuta/go-protoparser/internal/lexer"
-	"github.com/yoheimuta/go-protoparser/interpret/unordered"
-	"github.com/yoheimuta/go-protoparser/parser"
+	"github.com/yoheimuta/go-protoparser/v4/internal/lexer"
+	"github.com/yoheimuta/go-protoparser/v4/interpret/unordered"
+	"github.com/yoheimuta/go-protoparser/v4/parser"
 )
 
 // ParseConfig is a config for parser.


### PR DESCRIPTION
To allow for proper semver versioning, the package path should terminate wiht /v4, as mentioned in https://github.com/golang/go/wiki/Modules#how-are-v2-modules-treated-in-a-build-if-modules-support-is-not-enabled-how-does-minimal-module-compatibility-work-in-197-1103-and-111.

The reason for v4 and not v3 is that this is a gomod change which changes importpaths, and as such can be considered a breaking change.


This will allow users to point to the protoparser through `github.com/yoheimuta/go-protoparser v4.0.0` in their gomod file, instead of the current `github.com/yoheimuta/go-protoparser v1.3.1-0.20191127232502-7d443993ac15`, which is gross, requires `go get link@hash`, and more importantly, is not the default. (default is `github.com/yoheimuta/go-protoparser v3.4.0+incompatible`, an older version)