### PR TITLE
Remove internal errors for protolint to parse

### DIFF
--- a/parser/enum.go
+++ b/parser/enum.go
@@ -1,24 +1,9 @@
 package parser
 
 import (
-	"fmt"
-
 	"github.com/yoheimuta/go-protoparser/internal/lexer/scanner"
 	"github.com/yoheimuta/go-protoparser/parser/meta"
 )
-
-type parseEnumBodyStatementErr struct {
-	parseEnumFieldErr      error
-	parseEmptyStatementErr error
-}
-
-func (e *parseEnumBodyStatementErr) Error() string {
-	return fmt.Sprintf(
-		"%v:%v",
-		e.parseEnumFieldErr,
-		e.parseEmptyStatementErr,
-	)
-}
 
 // EnumValueOption is an option of a enumField.
 type EnumValueOption struct {
@@ -211,10 +196,12 @@ func (p *Parser) parseEnumBody() (
 				break
 			}
 
-			return nil, nil, scanner.Position{}, &parseEnumBodyStatementErr{
-				parseEnumFieldErr:      enumFieldErr,
-				parseEmptyStatementErr: emptyErr,
-			}
+			return nil, nil, scanner.Position{}, emptyErr
+
+			//&parseStatementErr{
+			//	parseFieldErr:          enumFieldErr,
+			//	parseEmptyStatementErr: emptyErr,
+			//}
 		}
 
 		p.MaybeScanInlineComment(stmt)

--- a/parser/extend.go
+++ b/parser/extend.go
@@ -1,24 +1,9 @@
 package parser
 
 import (
-	"fmt"
-
 	"github.com/yoheimuta/go-protoparser/internal/lexer/scanner"
 	"github.com/yoheimuta/go-protoparser/parser/meta"
 )
-
-type parseExtendBodyStatementErr struct {
-	parseFieldErr          error
-	parseEmptyStatementErr error
-}
-
-func (e *parseExtendBodyStatementErr) Error() string {
-	return fmt.Sprintf(
-		"%v:%v",
-		e.parseFieldErr,
-		e.parseEmptyStatementErr,
-	)
-}
 
 // Extend consists of a messageType and an extend body.
 type Extend struct {
@@ -172,10 +157,17 @@ func (p *Parser) parseExtendBody() (
 				break
 			}
 
-			return nil, nil, scanner.Position{}, &parseExtendBodyStatementErr{
-				parseFieldErr:          fieldErr,
-				parseEmptyStatementErr: emptyErr,
+			metaFieldErr := fieldErr.(*meta.Error)
+			return nil, nil, scanner.Position{}, &meta.Error{
+				Pos:      metaFieldErr.Pos,
+				Expected: "",
+				Found:    "",
 			}
+
+			//&parseStatementErr{
+			//	parseFieldErr:          fieldErr,
+			//	parseEmptyStatementErr: emptyErr,
+			//}
 		}
 
 		p.MaybeScanInlineComment(stmt)

--- a/parser/message.go
+++ b/parser/message.go
@@ -1,24 +1,9 @@
 package parser
 
 import (
-	"fmt"
-
 	"github.com/yoheimuta/go-protoparser/internal/lexer/scanner"
 	"github.com/yoheimuta/go-protoparser/parser/meta"
 )
-
-type parseMessageBodyStatementErr struct {
-	parseFieldErr          error
-	parseEmptyStatementErr error
-}
-
-func (e *parseMessageBodyStatementErr) Error() string {
-	return fmt.Sprintf(
-		"%v:%v",
-		e.parseFieldErr,
-		e.parseEmptyStatementErr,
-	)
-}
 
 // Message consists of a message name and a message body.
 type Message struct {
@@ -216,7 +201,6 @@ func (p *Parser) parseMessageBody() (
 			extensions.Comments = comments
 			stmt = extensions
 		default:
-			var ferr error
 			isGroup := p.peekIsGroup()
 			if isGroup {
 				groupField, groupErr := p.ParseGroupField()
@@ -225,7 +209,6 @@ func (p *Parser) parseMessageBody() (
 					stmt = groupField
 					break
 				}
-				ferr = groupErr
 				p.lex.UnNext()
 			} else {
 				field, fieldErr := p.ParseField()
@@ -234,7 +217,6 @@ func (p *Parser) parseMessageBody() (
 					stmt = field
 					break
 				}
-				ferr = fieldErr
 				p.lex.UnNext()
 			}
 
@@ -244,10 +226,7 @@ func (p *Parser) parseMessageBody() (
 				break
 			}
 
-			return nil, nil, scanner.Position{}, &parseMessageBodyStatementErr{
-				parseFieldErr:          ferr,
-				parseEmptyStatementErr: emptyErr,
-			}
+			return nil, nil, scanner.Position{}, emptyErr
 		}
 
 		p.MaybeScanInlineComment(stmt)

--- a/parser/reserved.go
+++ b/parser/reserved.go
@@ -1,20 +1,9 @@
 package parser
 
 import (
-	"fmt"
-
 	"github.com/yoheimuta/go-protoparser/internal/lexer/scanner"
 	"github.com/yoheimuta/go-protoparser/parser/meta"
 )
-
-type parseReservedErr struct {
-	parseRangesErr     error
-	parseFieldNamesErr error
-}
-
-func (e *parseReservedErr) Error() string {
-	return fmt.Sprintf("%v:%v", e.parseRangesErr, e.parseFieldNamesErr)
-}
 
 // Range is a range of field numbers. End is an optional value.
 type Range struct {
@@ -77,10 +66,7 @@ func (p *Parser) ParseReserved() (*Reserved, error) {
 			return nil, fieldNames, nil
 		}
 
-		return nil, nil, &parseReservedErr{
-			parseRangesErr:     err,
-			parseFieldNamesErr: ferr,
-		}
+		return nil, nil, ferr
 	}
 
 	ranges, fieldNames, err := parse()


### PR DESCRIPTION
Certain internal errors get thrown on parse issues, which makes it impossible to open a switch statement on them.

This PR removes those, instead returning the latest error, which seems to be the most relevant from the parse tests I ran.