### PR TITLE
feat: Allow a comment without newlines

### DIFF
--- a/internal/lexer/scanner/comment.go
+++ b/internal/lexer/scanner/comment.go
@@ -8,11 +8,11 @@ func (s *Scanner) scanComment() (string, error) {
 	switch ch {
 	case '/':
 		for ch != '\n' {
-			if s.isEOF() {
-				return lit, s.unexpected(eof, "\n")
-			}
 			lit += string(ch)
 
+			if s.isEOF() {
+				return lit, nil
+			}
 			ch = s.read()
 		}
 	case '*':

--- a/internal/lexer/scanner/scanner_test.go
+++ b/internal/lexer/scanner/scanner_test.go
@@ -306,6 +306,26 @@ fugafuga
 			},
 		},
 		{
+			name: "scan a comment without a newline",
+			input: `
+// hogehoge`,
+			mode: scanner.ScanComment,
+			wants: []want{
+				{
+					token: scanner.TCOMMENT,
+					text:  "// hogehoge",
+					pos: scanner.Position{
+						Position: meta.Position{
+
+							Offset: 1,
+							Line:   2,
+							Column: 1,
+						},
+					},
+				},
+			},
+		},
+		{
 			name:  "scan strLits",
 			input: `"" '' "abc" 'あいう' "\x1fzz" '\123\n\\'`,
 			mode:  scanner.ScanStrLit,


### PR DESCRIPTION
ref. [error parsring if file ends with comment _and_ no newline · Issue #49 · yoheimuta/go-protoparser](https://github.com/yoheimuta/go-protoparser/issues/49)