### PR TITLE
Fix empty field within option

### DIFF
--- a/internal/lexer/lexer.go
+++ b/internal/lexer/lexer.go
@@ -91,6 +91,14 @@ func (lex *Lexer) Next() {
 	}
 }
 
+// NextN scans the read buffer nth times.
+func (lex *Lexer) NextN(n int) {
+	for 0 < n {
+		lex.Next()
+		n--
+	}
+}
+
 // NextKeywordOrStrLit scans the read buffer with ScanKeyword or ScanStrLit modes.
 func (lex *Lexer) NextKeywordOrStrLit() {
 	lex.nextWithSpecificMode(scanner.ScanKeyword | scanner.ScanStrLit)
@@ -146,6 +154,21 @@ func (lex *Lexer) Peek() scanner.Token {
 	lex.Next()
 	defer lex.UnNext()
 	return lex.Token
+}
+
+// PeekN returns the nth next token with keeping the read buffer unchanged.
+func (lex *Lexer) PeekN(n int) scanner.Token {
+	var lasts [][]rune
+	for 0 < n {
+		lex.Next()
+		lasts = append(lasts, lex.RawText)
+		n--
+	}
+	token := lex.Token
+	for i := len(lasts) - 1; 0 <= i; i-- {
+		lex.UnNextTo(lasts[i])
+	}
+	return token
 }
 
 // UnNext put the latest text back to the read buffer.

--- a/internal/lexer/scanner/position.go
+++ b/internal/lexer/scanner/position.go
@@ -33,8 +33,8 @@ func (pos Position) String() string {
 
 // Advance advances the position value.
 func (pos *Position) Advance(r rune) {
-	len := utf8.RuneLen(r)
-	pos.Offset += len
+	length := utf8.RuneLen(r)
+	pos.Offset += length
 
 	if r == '\n' {
 		pos.columns[pos.Line] = pos.Column
@@ -48,8 +48,8 @@ func (pos *Position) Advance(r rune) {
 
 // Revert reverts the position value.
 func (pos *Position) Revert(r rune) {
-	len := utf8.RuneLen(r)
-	pos.Offset -= len
+	length := utf8.RuneLen(r)
+	pos.Offset -= length
 
 	if r == '\n' {
 		pos.Line--

--- a/parser/option.go
+++ b/parser/option.go
@@ -194,6 +194,12 @@ func (p *Parser) parseOptionConstant() (constant string, err error) {
 			return "", p.unexpected("constant or permissive mode")
 		}
 
+		// parses empty fields within an option
+		if p.lex.PeekN(2) == scanner.TRIGHTCURLY {
+			p.lex.NextN(2)
+			return "{}", nil
+		}
+
 		constant, err = p.parseCloudEndpointsOptionConstant()
 		if err != nil {
 			return "", err

--- a/parser/option_test.go
+++ b/parser/option_test.go
@@ -188,6 +188,28 @@ option (google.api.http) = {
 				},
 			},
 		},
+		{
+			name: "parses empty fields within an option",
+			input: `
+option (opt) = {
+    empty : {},
+    inner_empty : {
+    	empty : {},
+	},
+};`,
+			permissive: true,
+			wantOption: &parser.Option{
+				OptionName: "(opt)",
+				Constant:   `{empty:{},inner_empty:{empty:{},},}`,
+				Meta: meta.Meta{
+					Pos: meta.Position{
+						Offset: 1,
+						Line:   2,
+						Column: 1,
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
ref. [Parsing breaks on empty fields within options within RPCs · Issue #123 · yoheimuta/protolint](https://github.com/yoheimuta/protolint/issues/123)