### PR TITLE
Wrap errors from invalid bodies to be more descriptive

### DIFF
--- a/interpret/unordered/enum.go
+++ b/interpret/unordered/enum.go
@@ -38,7 +38,7 @@ func InterpretEnum(src *parser.Enum) (*Enum, error) {
 
 	enumBody, err := interpretEnumBody(src.EnumBody)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("invalid Enum %s: %w", src.EnumName, err)
 	}
 	return &Enum{
 		EnumName:                     src.EnumName,

--- a/interpret/unordered/message.go
+++ b/interpret/unordered/message.go
@@ -43,7 +43,7 @@ func InterpretMessage(src *parser.Message) (*Message, error) {
 
 	messageBody, err := interpretMessageBody(src.MessageBody)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("invalid Message %s: %w", src.MessageName, err)
 	}
 	return &Message{
 		MessageName:                  src.MessageName,

--- a/interpret/unordered/service.go
+++ b/interpret/unordered/service.go
@@ -36,7 +36,7 @@ func InterpretService(src *parser.Service) (*Service, error) {
 
 	serviceBody, err := interpretServiceBody(src.ServiceBody)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("invalid Service %s: %w", src.ServiceName, err)
 	}
 	return &Service{
 		ServiceName:                  src.ServiceName,


### PR DESCRIPTION
I had some difficulty locating a bug in a `.proto` file which was caused parsing to fail, but where our other tools (using protoc) were successfully generating the Go protobuf files, as the error message wasn't clear to me (as an infrequent user). 

I was receiving this error message:

```
invalid MessageBody type &{<nil>} of &{<nil>}
```

But it was unclear to me _which_ Message (in a fairly long proto file) was the source of this. Inevitably it was due to a typo with an extra semicolon at the end of one of the field definitions:

```
repeated string fields = 3 ;;
```

Could we perhaps wrap the error when interpreting Enums, Messages, and Services, with their name so it's easier to find the source of the error? This uses the [error wrapping introduced in Go 1.13](https://blog.golang.org/go1.13-errors), so that the original error can still be retrieved via `Unwrap()` and examined with Is and As. Very happy to change this if there's a preferred alternative! 


