### PR TITLE
Adapt enum and option latest spec

### DIFF
--- a/internal/lexer/scanner/scanner_test.go
+++ b/internal/lexer/scanner/scanner_test.go
@@ -93,7 +93,7 @@ func TestScanner_Scan(t *testing.T) {
 					},
 				},
 				{
-					token: scanner.TILLEGAL,
+					token: scanner.TMINUS,
 					text:  "-",
 					pos: scanner.Position{
 						Position: meta.Position{

--- a/internal/lexer/scanner/token.go
+++ b/internal/lexer/scanner/token.go
@@ -36,6 +36,7 @@ const (
 	TGREATER     // >
 	TCOMMA       // ,
 	TDOT         // .
+	TMINUS       // -
 
 	// Keywords
 	TSYNTAX
@@ -78,6 +79,7 @@ func asMiscToken(ch rune) Token {
 		'>':  TGREATER,
 		',':  TCOMMA,
 		'.':  TDOT,
+		'-':  TMINUS,
 	}
 	if t, ok := m[ch]; ok {
 		return t

--- a/parser/enum.go
+++ b/parser/enum.go
@@ -222,7 +222,7 @@ func (p *Parser) parseEnumBody() (
 	}
 }
 
-// enumField = ident "=" intLit [ "[" enumValueOption { ","  enumValueOption } "]" ]";"
+// enumField = [ "-" ] ident "=" intLit [ "[" enumValueOption { ","  enumValueOption } "]" ]";"
 // See https://developers.google.com/protocol-buffers/docs/reference/proto3-spec#enum_definition
 func (p *Parser) parseEnumField() (*EnumField, error) {
 	p.lex.Next()
@@ -237,11 +237,17 @@ func (p *Parser) parseEnumField() (*EnumField, error) {
 		return nil, p.unexpected("=")
 	}
 
+	var intLit string
+	p.lex.ConsumeToken(scanner.TMINUS)
+	if p.lex.Token == scanner.TMINUS {
+		intLit = "-"
+	}
+
 	p.lex.NextNumberLit()
 	if p.lex.Token != scanner.TINTLIT {
 		return nil, p.unexpected("intLit")
 	}
-	number := p.lex.Text
+	intLit += p.lex.Text
 
 	enumValueOptions, err := p.parseEnumValueOptions()
 	if err != nil {
@@ -255,7 +261,7 @@ func (p *Parser) parseEnumField() (*EnumField, error) {
 
 	return &EnumField{
 		Ident:            ident,
-		Number:           number,
+		Number:           intLit,
 		EnumValueOptions: enumValueOptions,
 		Meta:             meta.Meta{Pos: startPos.Position},
 	}, nil

--- a/parser/enum_test.go
+++ b/parser/enum_test.go
@@ -552,6 +552,65 @@ func TestParser_ParseEnum(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "parsing a negative enum field",
+			input: `enum TestNegativeValue {
+  NEGATIVE_CONSTANT = -1;
+  ZERO_CONSTANT = 0;
+  POSITIVE_CONSTANT = 1;
+}
+`,
+			wantEnum: &parser.Enum{
+				EnumName: "TestNegativeValue",
+				EnumBody: []parser.Visitee{
+					&parser.EnumField{
+						Ident:  "NEGATIVE_CONSTANT",
+						Number: "-1",
+						Meta: meta.Meta{
+							Pos: meta.Position{
+								Offset: 27,
+								Line:   2,
+								Column: 3,
+							},
+						},
+					},
+					&parser.EnumField{
+						Ident:  "ZERO_CONSTANT",
+						Number: "0",
+						Meta: meta.Meta{
+							Pos: meta.Position{
+								Offset: 53,
+								Line:   3,
+								Column: 3,
+							},
+						},
+					},
+					&parser.EnumField{
+						Ident:  "POSITIVE_CONSTANT",
+						Number: "1",
+						Meta: meta.Meta{
+							Pos: meta.Position{
+								Offset: 74,
+								Line:   4,
+								Column: 3,
+							},
+						},
+					},
+				},
+				Meta: meta.Meta{
+					Pos: meta.Position{
+						Offset: 0,
+						Line:   1,
+						Column: 1,
+					},
+					LastPos: meta.Position{
+						Offset: 97,
+						Line:   5,
+						Column: 1,
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/parser/oneof.go
+++ b/parser/oneof.go
@@ -82,7 +82,7 @@ func (o *Oneof) Accept(v Visitor) {
 }
 
 // ParseOneof parses the oneof.
-//  oneof = "oneof" oneofName "{" { oneofField | emptyStatement } "}"
+//  oneof = "oneof" oneofName "{" { option | oneofField | emptyStatement } "}"
 //
 // See https://developers.google.com/protocol-buffers/docs/reference/proto3-spec#oneof_and_oneof_field
 func (p *Parser) ParseOneof() (*Oneof, error) {
@@ -118,8 +118,8 @@ func (p *Parser) ParseOneof() (*Oneof, error) {
 		p.lex.NextKeyword()
 		token := p.lex.Token
 		p.lex.UnNext()
-		if p.permissive && token == scanner.TOPTION {
-			// accept an option. See https://github.com/yoheimuta/go-protoparser/v4/issues/39.
+		if token == scanner.TOPTION {
+			// See https://github.com/yoheimuta/go-protoparser/issues/57
 			option, err := p.ParseOption()
 			if err != nil {
 				return nil, err

--- a/parser/oneof_test.go
+++ b/parser/oneof_test.go
@@ -368,7 +368,7 @@ func TestParser_ParseOneof(t *testing.T) {
 			},
 		},
 		{
-			name: "accept options. See https://github.com/yoheimuta/go-protoparser/v4/issues/39",
+			name: "accept options. See https://github.com/yoheimuta/go-protoparser/issues/39",
 			input: `oneof something {
   option (validator.oneof) = {required: true};
   uint32 three_int = 5 [(validator.field) = {int_gt: 20}];
@@ -457,6 +457,41 @@ func TestParser_ParseOneof(t *testing.T) {
 					LastPos: meta.Position{
 						Offset: 254,
 						Line:   6,
+						Column: 1,
+					},
+				},
+			},
+		},
+		{
+			name: "accept a simple option without a permissive option. See https://github.com/yoheimuta/go-protoparser/issues/57",
+			input: `oneof something {
+  option (my_option).a = true;
+}
+`,
+			wantOneof: &parser.Oneof{
+				Options: []*parser.Option{
+					{
+						OptionName: "(my_option).a",
+						Constant:   "true",
+						Meta: meta.Meta{
+							Pos: meta.Position{
+								Offset: 20,
+								Line:   2,
+								Column: 3,
+							},
+						},
+					},
+				},
+				OneofName: "something",
+				Meta: meta.Meta{
+					Pos: meta.Position{
+						Offset: 0,
+						Line:   1,
+						Column: 1,
+					},
+					LastPos: meta.Position{
+						Offset: 49,
+						Line:   3,
 						Column: 1,
 					},
 				},


### PR DESCRIPTION
ref. [Adapt the parser rule to the official spec updated so far · Issue #57 · yoheimuta/go-protoparser](https://github.com/yoheimuta/go-protoparser/issues/57)