### PR TITLE
UnorderedInterpret: handle EmptyStatement in MessageBody 

### DIFF
--- a/interpret/unordered/enum.go
+++ b/interpret/unordered/enum.go
@@ -69,7 +69,7 @@ func interpretEnumBody(src []parser.Visitee) (
 		case *parser.EmptyStatement:
 			emptyStatements = append(emptyStatements, t)
 		default:
-			return nil, fmt.Errorf("invalid EnumBody type %v of %v", t, s)
+			return nil, fmt.Errorf("invalid EnumBody type %T of %v", t, t)
 		}
 	}
 	return &EnumBody{

--- a/interpret/unordered/extend.go
+++ b/interpret/unordered/extend.go
@@ -61,7 +61,7 @@ func interpretExtendBody(src []parser.Visitee) (
 		case *parser.EmptyStatement:
 			emptyStatements = append(emptyStatements, t)
 		default:
-			return nil, fmt.Errorf("invalid ExtendBody type %v of %v", t, s)
+			return nil, fmt.Errorf("invalid ExtendBody type %T of %v", t, t)
 		}
 	}
 	return &ExtendBody{

--- a/interpret/unordered/message.go
+++ b/interpret/unordered/message.go
@@ -101,7 +101,7 @@ func interpretMessageBody(src []parser.Visitee) (
 		case *parser.EmptyStatement:
 			emptyStatements = append(emptyStatements, t)
 		default:
-			return nil, fmt.Errorf("invalid MessageBody type %v of %v", t, s)
+			return nil, fmt.Errorf("invalid MessageBody type %T of %v", t, t)
 		}
 	}
 	return &MessageBody{

--- a/interpret/unordered/message.go
+++ b/interpret/unordered/message.go
@@ -9,15 +9,16 @@ import (
 
 // MessageBody is unordered in nature, but each slice field preserves the original order.
 type MessageBody struct {
-	Fields   []*parser.Field
-	Enums    []*Enum
-	Messages []*Message
-	Options  []*parser.Option
-	Oneofs   []*parser.Oneof
-	Maps     []*parser.MapField
-	Groups   []*parser.GroupField
-	Reserves []*parser.Reserved
-	Extends  []*parser.Extend
+	Fields          []*parser.Field
+	Enums           []*Enum
+	Messages        []*Message
+	Options         []*parser.Option
+	Oneofs          []*parser.Oneof
+	Maps            []*parser.MapField
+	Groups          []*parser.GroupField
+	Reserves        []*parser.Reserved
+	Extends         []*parser.Extend
+	EmptyStatements []*parser.EmptyStatement
 }
 
 // Message consists of a message name and a message body.
@@ -68,6 +69,7 @@ func interpretMessageBody(src []parser.Visitee) (
 	var groups []*parser.GroupField
 	var reserves []*parser.Reserved
 	var extends []*parser.Extend
+	var emptyStatements []*parser.EmptyStatement
 	for _, s := range src {
 		switch t := s.(type) {
 		case *parser.Field:
@@ -96,19 +98,22 @@ func interpretMessageBody(src []parser.Visitee) (
 			reserves = append(reserves, t)
 		case *parser.Extend:
 			extends = append(extends, t)
+		case *parser.EmptyStatement:
+			emptyStatements = append(emptyStatements, t)
 		default:
 			return nil, fmt.Errorf("invalid MessageBody type %v of %v", t, s)
 		}
 	}
 	return &MessageBody{
-		Fields:   fields,
-		Enums:    enums,
-		Messages: messages,
-		Options:  options,
-		Oneofs:   oneofs,
-		Maps:     maps,
-		Groups:   groups,
-		Reserves: reserves,
-		Extends:  extends,
+		Fields:          fields,
+		Enums:           enums,
+		Messages:        messages,
+		Options:         options,
+		Oneofs:          oneofs,
+		Maps:            maps,
+		Groups:          groups,
+		Reserves:        reserves,
+		Extends:         extends,
+		EmptyStatements: emptyStatements,
 	}, nil
 }

--- a/interpret/unordered/proto.go
+++ b/interpret/unordered/proto.go
@@ -87,7 +87,7 @@ func interpretProtoBody(src []parser.Visitee) (
 		case *parser.EmptyStatement:
 			emptyStatements = append(emptyStatements, t)
 		default:
-			return nil, fmt.Errorf("invalid ProtoBody type %v of %v", t, s)
+			return nil, fmt.Errorf("invalid ProtoBody type %T of %v", t, t)
 		}
 	}
 	return &ProtoBody{

--- a/interpret/unordered/service.go
+++ b/interpret/unordered/service.go
@@ -61,7 +61,7 @@ func interpretServiceBody(src []parser.Visitee) (
 		case *parser.RPC:
 			rpcs = append(rpcs, t)
 		default:
-			return nil, fmt.Errorf("invalid ServiceBody type %v of %v", t, s)
+			return nil, fmt.Errorf("invalid ServiceBody type %T of %v", t, t)
 		}
 	}
 	return &ServiceBody{


### PR DESCRIPTION
An additional trailing semicolon in the body of a message currently causes `UnorderedInterpret` to fail.

For example, changing the example proto file from the `README`

https://github.com/yoheimuta/go-protoparser/blob/a1aa0a07fe86a183dd06da85e9c5ef6f9a11faa1/README.md?plain=1#L36-L44

to add an additional semicolon somewhere in `outer` (e.g. `option (my_option).a = true;;`) causes the following error to be returned:

```
invalid MessageBody type &{<nil>} of &{<nil>}
```

This PR causes these empty statements to be included on the returned `MessageBody` instead.

-----

While debugging this issue, I also noticed the error message was repeating the same format argument. In the second commit I fixed the error messages so they contain the name of the invalid type and then a representation of the value.

```
invalid MessageBody type *parser.SomeUnexpectedStatement of &{<nil>}
```
