### PR TITLE
chore: Update go version to v1.18.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,6 @@ jobs:
   lint:
     docker:
       - image: cimg/go:1.18.1
-    working_directory: /go/src/github.com/yoheimuta/go-protoparser
     steps:
       - checkout
       - run: make dev/install/dep
@@ -11,7 +10,6 @@ jobs:
   test:
     docker:
       - image: cimg/go:1.18.1
-    working_directory: /go/src/github.com/yoheimuta/go-protoparser
     steps:
       - checkout
       - run: make test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   lint:
     docker:
-      - image: circleci/golang:1.15.4
+      - image: cimg/go:1.18.1
     working_directory: /go/src/github.com/yoheimuta/go-protoparser
     steps:
       - checkout
@@ -10,7 +10,7 @@ jobs:
       - run: make test/lint
   test:
     docker:
-      - image: circleci/golang:1.15.4
+      - image: cimg/go:1.18.1
     working_directory: /go/src/github.com/yoheimuta/go-protoparser
     steps:
       - checkout

--- a/.circleci/install_dep.sh
+++ b/.circleci/install_dep.sh
@@ -8,4 +8,5 @@ go install github.com/kisielk/errcheck@latest
 go install github.com/gordonklaus/ineffassign@latest
 go install github.com/opennota/check/cmd/varcheck@latest
 go install github.com/opennota/check/cmd/aligncheck@latest
-go install github.com/mdempsky/unconvert@latest
+# Comment out because of the error: internal error: package "fmt" without types was imported from
+# go install github.com/mdempsky/unconvert@latest

--- a/.circleci/install_dep.sh
+++ b/.circleci/install_dep.sh
@@ -2,10 +2,10 @@
 
 set -euxo pipefail
 
-go get -u golang.org/x/tools/cmd/goimports
-go get -u golang.org/x/lint/golint
-go get -u github.com/kisielk/errcheck
-go get -u github.com/gordonklaus/ineffassign
-go get -u github.com/opennota/check/cmd/varcheck
-go get -u github.com/opennota/check/cmd/aligncheck
-go get -u github.com/mdempsky/unconvert
+go install golang.org/x/tools/cmd/goimports@latest
+go install golang.org/x/lint/golint@latest
+go install github.com/kisielk/errcheck@latest
+go install github.com/gordonklaus/ineffassign@latest
+go install github.com/opennota/check/cmd/varcheck@latest
+go install github.com/opennota/check/cmd/aligncheck@latest
+go install github.com/mdempsky/unconvert@latest

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,8 @@ test/lint:
 	# checks no used assigned value.
 	ineffassign .
 	# checks dispensable type conversions.
-	unconvert -v ./...
+	## Comment out because of the error: internal error: package "fmt" without types was imported from
+	#unconvert -v ./...
 
 ## dev/install/dep installs depenencies required for development.
 dev/install/dep:


### PR DESCRIPTION
ref. https://app.circleci.com/pipelines/github/yoheimuta/go-protoparser/183/workflows/a14f9479-57e3-4733-b9d7-9c75081011b9/jobs/303

```
 golang.org/x/sys/execabs
/go/pkg/mod/golang.org/x/sys@v0.0.0-20220502124256-b6088ccd6cba/execabs/execabs_go119.go:11:6: isGo119ErrDot redeclared in this block
	previous declaration at /go/pkg/mod/golang.org/x/sys@v0.0.0-20220502124256-b6088ccd6cba/execabs/execabs_go118.go:9:31
note: module requires Go 1.17
make: *** [Makefile:34: dev/install/dep] Error 2

Exited with code exit status 2
```