### PR TITLE
[gosec-G307] fix gosec issue in example

### DIFF
--- a/_example/dump/main.go
+++ b/_example/dump/main.go
@@ -26,7 +26,11 @@ func run() int {
 		fmt.Fprintf(os.Stderr, "failed to open %s, err %v\n", *proto, err)
 		return 1
 	}
-	defer reader.Close()
+	defer func() {
+		if err := reader.Close(); err != nil {
+			fmt.Printf("Error closing file: %s\n", err)
+		}
+	}()
 
 	got, err := protoparser.Parse(
 		reader,


### PR DESCRIPTION
tldr; I am using this project and its failing my CI build due to an issue raised by gosec [G307](https://github.com/securego/gosec/issues/512). I know I can exclude the example dir from the CI check, but for reasons more than one, it is much simpler to fix the example here directly.