### PR TITLE
add extensions field to Message struct so interpreting  proto file wi…

### DIFF
--- a/interpret/unordered/message.go
+++ b/interpret/unordered/message.go
@@ -19,6 +19,7 @@ type MessageBody struct {
 	Reserves        []*parser.Reserved
 	Extends         []*parser.Extend
 	EmptyStatements []*parser.EmptyStatement
+	Extensions      []*parser.Extensions
 }
 
 // Message consists of a message name and a message body.
@@ -70,6 +71,7 @@ func interpretMessageBody(src []parser.Visitee) (
 	var reserves []*parser.Reserved
 	var extends []*parser.Extend
 	var emptyStatements []*parser.EmptyStatement
+	var extensions []*parser.Extensions
 	for _, s := range src {
 		switch t := s.(type) {
 		case *parser.Field:
@@ -100,6 +102,8 @@ func interpretMessageBody(src []parser.Visitee) (
 			extends = append(extends, t)
 		case *parser.EmptyStatement:
 			emptyStatements = append(emptyStatements, t)
+		case *parser.Extensions:
+			extensions = append(extensions, t)
 		default:
 			return nil, fmt.Errorf("invalid MessageBody type %T of %v", t, t)
 		}
@@ -115,5 +119,6 @@ func interpretMessageBody(src []parser.Visitee) (
 		Reserves:        reserves,
 		Extends:         extends,
 		EmptyStatements: emptyStatements,
+		Extensions:      extensions,
 	}, nil
 }


### PR DESCRIPTION
…th extensions would not fail

@yoheimuta I created this pull request by adding a slice field to Message struct. Even though I see only one extenisons is defined per message, I don't see anywhere in the spec  whether only one extensions declaration is allowed, so I am adding it as a slice instead of a pointer field. Of course, the name `Extensions` is kind of awkward.