### PR TITLE
docs(remove license): copy rights from error

### DIFF
--- a/parser/meta/error.go
+++ b/parser/meta/error.go
@@ -1,5 +1,3 @@
-// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
-
 package meta
 
 import "fmt"


### PR DESCRIPTION


remove copy rights from `meta/error`