### PR TITLE
Correctly parse bracedFullIdent at all places it can occur in optionName

### DIFF
--- a/parser/option_test.go
+++ b/parser/option_test.go
@@ -313,6 +313,27 @@ body:"*"}]}`,
 				},
 			},
 		},
+		{
+			name:       `parsing bracedFullIdent as part of optionName`,
+			input:      `option foo.(bar.baz).name = "value";`,
+			permissive: true,
+			wantOption: &parser.Option{
+				OptionName: "foo.(bar.baz).name",
+				Constant:   `"value"`,
+				Meta: meta.Meta{
+					Pos: meta.Position{
+						Offset: 0,
+						Line:   1,
+						Column: 1,
+					},
+					LastPos: meta.Position{
+						Offset: 35,
+						Line:   1,
+						Column: 36,
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
The spec contains the following regarding optionNames:

   option = "option" optionName  "=" constant ";"
   optionName = ( ident | bracedFullIdent ) { "." ( ident | bracedFullIdent ) }
   bracedFullIdent = "(" ["."] fullIdent ")"

In the previous implementation, only the whole optionName could be in braces, while the spec also allows parts (between dots) to be braced.

An example in the wild on which this would fail is the following snippet, taken from the "Go Opaque API Migration" guide (https://protobuf.dev/reference/go/opaque-migration/):

    edition = "2023";

    package log;

    import "google/protobuf/go_features.proto";
    option features.(pb.go).api_level = API_OPAQUE;

    message LogEntry { … }